### PR TITLE
Change contract in ContourLayout

### DIFF
--- a/app/src/main/java/com/squareup/contour/sample/SampleView1.kt
+++ b/app/src/main/java/com/squareup/contour/sample/SampleView1.kt
@@ -24,70 +24,34 @@ class SampleView1(context: SampleActivity) : ContourLayout(context) {
   private fun siskoWisdom(amount: Float): String =
     siskoWisdom.substring(0, (siskoWisdom.length * amount.coerceIn(0f, 1f)).toInt())
 
-  private val avatar: AvatarImageView =
-    AvatarImageView(context).contourOf {
+  private val avatar =
+    AvatarImageView(context).apply {
       Picasso.get()
           .load("https://upload.wikimedia.org/wikipedia/en/9/92/BenSisko.jpg")
           .into(this)
       scaleType = ImageView.ScaleType.CENTER_CROP
       paint.strokeWidth = 3f.dip
-
-      LayoutSpec(
-          leftTo {
-            parent.left() + 15.dip
-          }.widthOf {
-            name.width()
-          },
-          topTo {
-            parent.top() + 15.dip
-          }.heightOf {
-            name.width()
-                .toY()
-          }
-      )
     }
 
   private val name =
-    TextView(context).contourOf {
+    TextView(context).apply {
       text = "Ben Sisko"
       setTextColor(White)
       setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18f)
-      LayoutSpec(
-          leftTo { avatar.left() },
-          topTo { avatar.bottom() + 5.dip }
-
-      )
     }
 
   private val description =
-    TextView(context).contourOf {
+    TextView(context).apply {
       text = siskoWisdom(0.25f)
       setTextColor(White)
       setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14f)
-      LayoutSpec(
-          leftTo {
-            name.right() + 15.dip
-          }.rightTo {
-            parent.right() - 15.dip
-          },
-          topTo {
-            parent.top() + 15.dip
-          }
-      )
     }
 
   private val starDate =
-    TextView(context).contourOf {
+    TextView(context).apply {
       text = "Stardate: 23634.1"
       setTextColor(White)
       setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18f)
-      LayoutSpec(
-          rightTo { parent.right() - 15.dip },
-          maxOf(
-              topTo { description.bottom() + 5.dip },
-              bottomTo { name.bottom() }
-          )
-      )
     }
 
   init {
@@ -111,5 +75,42 @@ class SampleView1(context: SampleActivity) : ContourLayout(context) {
             .start()
       }
     }
+  }
+
+  override fun onInitializeLayout() {
+    avatar.applyLayout(
+        leftTo {
+          parent.left() + 15.dip
+        }.widthOf {
+          name.width()
+        },
+        topTo {
+          parent.top() + 15.dip
+        }.heightOf {
+          name.width()
+              .toY()
+        }
+    )
+    name.applyLayout(
+        leftTo { avatar.left() },
+        topTo { avatar.bottom() + 5.dip }
+    )
+    description.applyLayout(
+        leftTo {
+          name.right() + 15.dip
+        }.rightTo {
+          parent.right() - 15.dip
+        },
+        topTo {
+          parent.top() + 15.dip
+        }
+    )
+    starDate.applyLayout(
+        rightTo { parent.right() - 15.dip },
+        maxOf(
+            topTo { description.bottom() + 5.dip },
+            bottomTo { name.bottom() }
+        )
+    )
   }
 }

--- a/app/src/main/java/com/squareup/contour/sample/SampleView2.kt
+++ b/app/src/main/java/com/squareup/contour/sample/SampleView2.kt
@@ -22,53 +22,26 @@ class SampleView2(context: SampleActivity) : ContourLayout(context) {
   )
 
   private val avatar =
-    AvatarImageView(context).contourOf {
+    AvatarImageView(context).apply {
       scaleType = ImageView.ScaleType.CENTER_CROP
       Picasso.get()
           .load("https://upload.wikimedia.org/wikipedia/en/9/92/BenSisko.jpg")
           .into(this)
       paint.strokeWidth = 3f.dip
-      LayoutSpec(
-          leftTo {
-            parent.left() + 15.dip
-          }.widthOf {
-            50.dip.toXInt()
-          },
-          topTo {
-            parent.top() + 15.dip
-          }.heightOf {
-            50.dip.toYInt()
-          }
-      )
     }
 
-  private val name: TextView =
-    TextView(context).contourOf {
+  private val name =
+    TextView(context).apply {
       text = "Ben Sisko"
       setSingleLine()
       ellipsize = TruncateAt.END
       setTextColor(White)
       setTextSize(TypedValue.COMPLEX_UNIT_DIP, 24f)
-      LayoutSpec(
-          leftTo {
-            avatar.right() + 15.dip
-          }.rightTo(AtMost) {
-            parent.width() - checkmark.width() - 30.dip
-          },
-          centerVerticallyTo { parent.centerY() }
-      )
     }
 
   private val checkmark =
-    ImageView(context).contourOf {
+    ImageView(context).apply {
       setImageResource(R.drawable.check_mark)
-      LayoutSpec(
-          minOf(
-              leftTo { name.right() + 15.dip },
-              rightTo { parent.width() - 15.dip }
-          ),
-          centerVerticallyTo { name.centerY() }
-      )
     }
 
   init {
@@ -94,5 +67,35 @@ class SampleView2(context: SampleActivity) : ContourLayout(context) {
             .start()
       }
     }
+  }
+
+  override fun onInitializeLayout() {
+    avatar.applyLayout(
+        leftTo {
+          parent.left() + 15.dip
+        }.widthOf {
+          50.dip.toXInt()
+        },
+        topTo {
+          parent.top() + 15.dip
+        }.heightOf {
+          50.dip.toYInt()
+        }
+    )
+    name.applyLayout(
+        leftTo {
+          avatar.right() + 15.dip
+        }.rightTo(AtMost) {
+          parent.width() - checkmark.width() - 30.dip
+        },
+        centerVerticallyTo { parent.centerY() }
+    )
+    checkmark.applyLayout(
+        minOf(
+            leftTo { name.right() + 15.dip },
+            rightTo { parent.width() - 15.dip }
+        ),
+        centerVerticallyTo { name.centerY() }
+    )
   }
 }


### PR DESCRIPTION
I've received a piece of feedback a couple of times on ContourLayout: That it would feel more clean to configure layout in a separate function. I've tried that here, and ultimately I think it is a better contract. Children views no longer use contourOf to setup layout. Instead the ContourLayout subclass overrides
onInitializeLayout() where applyLayout() should now be called.

**Pros:**

- Separation of layout logic from view configuration logic.
- This should make ContourLayout compatible in XML. This isn't something I want to optimize for, but would make migration to ContourLayout easier.
- Feels more symmetric to `updateLayoutSpec()` (which will be renamed). There are now `apply` & `update` functions for defining and updating layouts.
- `contourOf` signature was weird - mutating the receiver and then returning a LayoutSpec in a single lambda feels really gross. This change deprecates that.
- Reduces Kotlin recursive type inference errors.

**Cons:**

- Easier to forget to configure a layout now that the API does not force you in `contourOf`
- Subtle side-effect to this change. Views won't be added to the `ConstraintLayout` `ViewGroup` until `onAttachToWindow` or `onMeasure` are called. This *probably* doesn't matter, but may have unexpected consequences. 
