### PR TITLE
Add first class support for Percentages and Floats

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -31,9 +31,7 @@ open class ContourLayout(
     get() = density * this
 
   inline fun Int.toXInt(): XInt = XInt(this)
-  inline fun Float.toXInt(): XInt = XInt(toInt())
   inline fun Int.toYInt(): YInt = YInt(this)
-  inline fun Float.toYInt(): YInt = YInt(toInt())
 
   private val widthConfig = SizeConfig()
   private val heightConfig = SizeConfig()

--- a/contour/src/main/kotlin/com/squareup/contour/GeometryProvider.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/GeometryProvider.kt
@@ -6,13 +6,11 @@ interface GeometryProvider {
   fun left(): XInt
   fun right(): XInt
   fun width(): XInt
-  fun width(amount: Float): XInt
   fun centerX(): XInt
 
   fun top(): YInt
   fun bottom(): YInt
   fun height(): YInt
-  fun height(amount: Float): YInt
   fun centerY(): YInt
 }
 

--- a/contour/src/main/kotlin/com/squareup/contour/XInt.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/XInt.kt
@@ -19,6 +19,11 @@ inline class XInt(val value: Int) {
   inline operator fun times(other: XInt): XInt =
     XInt(value * other.value)
 
+  inline operator fun times(multiplier: Float): XInt =
+    XInt((value * multiplier).toInt())
+  inline operator fun times(multiplier: Double): XInt =
+    XInt((value * multiplier).toInt())
+
   inline operator fun div(other: Int): XInt =
     XInt(value / other)
   inline operator fun div(other: XInt): XInt =

--- a/contour/src/main/kotlin/com/squareup/contour/YInt.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/YInt.kt
@@ -19,6 +19,11 @@ inline class YInt(val value: Int) {
   inline operator fun times(other: YInt): YInt =
     YInt(value * other.value)
 
+  inline operator fun times(multiplier: Float): YInt =
+    YInt((value * multiplier).toInt())
+  inline operator fun times(multiplier: Double): YInt =
+    YInt((value * multiplier).toInt())
+
   inline operator fun div(other: Int): YInt =
     YInt(value / other)
   inline operator fun div(other: YInt): YInt =

--- a/contour/src/main/kotlin/com/squareup/contour/utils/XYIntUtils.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/utils/XYIntUtils.kt
@@ -21,6 +21,4 @@ internal inline fun unwrapXProvider(crossinline lambda: XProvider): IntProvider 
 internal inline fun unwrapYProvider(crossinline lambda: YProvider): IntProvider = { lambda().value }
 
 internal inline fun Int.toXInt(): XInt = XInt(this)
-internal inline fun Float.toXInt(): XInt = XInt(toInt())
 internal inline fun Int.toYInt(): YInt = YInt(this)
-internal inline fun Float.toYInt(): YInt = YInt(toInt())

--- a/contour/src/main/kotlin/com/squareup/contour/wrappers/ParentGeometryProvider.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/wrappers/ParentGeometryProvider.kt
@@ -14,12 +14,10 @@ internal class ParentGeometryProvider(
   override fun left(): XInt = XInt.ZERO
   override fun right(): XInt = widthConfig.resolve().toXInt()
   override fun width(): XInt = widthConfig.resolve().toXInt()
-  override fun width(amount: Float): XInt = (widthConfig.resolve() * amount).toXInt()
   override fun centerX(): XInt = (widthConfig.resolve() / 2).toXInt()
 
   override fun top(): YInt = YInt.ZERO
   override fun bottom(): YInt = heightConfig.resolve().toYInt()
   override fun height(): YInt = heightConfig.resolve().toYInt()
-  override fun height(amount: Float): YInt = (heightConfig.resolve() * amount).toYInt()
   override fun centerY(): YInt = heightConfig.resolve().toYInt() / 2
 }

--- a/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
@@ -134,4 +134,50 @@ class ContourTests {
         assertThat(view0.top).isEqualTo(30)
         assertThat(view1.top).isEqualTo(20)
     }
+
+    @Test
+    fun `width as percentage of parents width`() {
+        val view = View(activity)
+
+        var pct = 0.4f
+
+        val layout = contourLayout(
+            activity,
+            width = 50
+        ) {
+            view.applyLayout(
+                leftTo { parent.left() }.widthOf { parent.width() * pct },
+                centerVerticallyTo { parent.centerY() }
+            )
+        }
+
+        assertThat(view.width).isEqualTo(20) // 50 * 0.4
+
+        pct = 0.51f
+        layout.forceRelayout()
+        assertThat(view.width).isEqualTo(25) // 50 * 0.51 = 25.5 ~= 25 floored
+    }
+
+    @Test
+    fun `height as percentage of parents height`() {
+        val view = View(activity)
+
+        var pct = 0.1f
+
+        val layout = contourLayout(
+            activity,
+            width = 260
+        ) {
+            view.applyLayout(
+                leftTo { parent.left() }.widthOf { parent.width() * pct },
+                centerVerticallyTo { parent.centerY() }
+            )
+        }
+
+        assertThat(view.width).isEqualTo(26) // 260 * 0.1
+
+        pct = 0.13f
+        layout.forceRelayout()
+        assertThat(view.width).isEqualTo(33) // 260 * 0.13 = 33.8 ~= 33 floored
+    }
 }


### PR DESCRIPTION
I tried restricting the values for `Percentage` using the androidx annotation `FloatRange`, but couldn't get the lint check to work. Ideally we'd have that annotation in place and have warnings thrown when consumers input numbers outside those bounds (since it should be a very deliberate action), but that can be added in the future.