### PR TITLE
ContourLayouts that are GONE should not participate in layout

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -206,6 +206,10 @@ open class ContourLayout(
   ) {
     for (i in 0 until childCount) {
       val child = getChildAt(i)
+      if (child.visibility == GONE) {
+        continue
+      }
+
       val params = child.spec()
       params.measureSelf()
       child.layout(


### PR DESCRIPTION
While a previous improvement ensured that GONE views always got measured at width=0 and height=0, this prevents attempts at laying them out altogether.

Because a view (`MyRedactedView`) that was gone was getting laid out, its subviews' layout provider lambdas were getting run, and on attempting to resolve things like parent.height() would crash because the parent hadn't measured itself.

Redacted context of crash that was being observed:
```
java.lang.IllegalArgumentException: Triggering layout before parent geometry available
        at com.squareup.contour.constraints.SizeConfig.resolve(SizeConfig.kt:26)
        at com.squareup.contour.wrappers.ParentGeometry.height(ParentGeometry.kt:37)
        at com.squareup.cash.MyRedactedView$onInitializeLayout$3.invoke(MyRedactedView.kt:49)
        at com.squareup.cash.MyRedactedView$onInitializeLayout$3.invoke(MyRedactedView.kt:19)
        at com.squareup.contour.utils.XYIntUtilsKt$unwrapYFloatLambda$1.invoke(XYIntUtils.kt:55)
        at com.squareup.contour.utils.XYIntUtilsKt$unwrapYFloatLambda$1.invoke(Unknown Source:2)
        at com.squareup.contour.constraints.Constraint.resolve(Constraint.kt:48)
        at com.squareup.contour.solvers.SimpleAxisSolver.measureSpec(SimpleAxisSolver.kt:173)
        at com.squareup.contour.ContourLayout$LayoutSpec.measureSelf$contour_debug(ContourLayout.kt:577)
        at com.squareup.contour.ContourLayout.onLayout(ContourLayout.kt:210)
        at android.view.View.layout(View.java:19590)
```