### PR TITLE
Add convenience applyEmptyLayout method for adding a view to the parent without laying it out

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -335,6 +335,16 @@ open class ContourLayout(
   }
 
   /**
+   * Convenience method for adding a [View] as child to the [ContourLayout] with a zero-width, zero-height
+   * [LayoutSpec].
+   * @receiver the view to configure and add to the [ContourLayout]
+   */
+  fun View.applyEmptyLayout() = applyLayout(
+      x = leftTo { parent.left() }.widthOf { 0.toXInt() },
+      y = topTo { parent.top() }.heightOf { 0.toYInt() }
+  )
+
+  /**
    * Updates the layout configuration of receiver view with new optional [XAxisSolver] and/or [YAxisSolver]
    * @receiver the view to configure
    * @param x configures how the [View] will be positioned and sized on the x-axis.


### PR DESCRIPTION
This is important instead of just doing `addView` so that the view's layoutParams get properly provisioned from the get go with a LayoutSpec.