### PR TITLE
Introduce layoutBy{} extension for laying views during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
-Change Log
-==========
+# Change Log
+
+## Version 0.1.8
+
+_2020-06-11_
+
+  * Change: Renames `applyLayout()` to `layoutBy()`.
+  * New: Adds a `layoutBy {}` extension function for safely laying out nested contour views. This is
+    useful because Kotlin's `apply {}` extension makes it extremely easy to call `layoutBy()` on the
+    wrong scope, resulting in a `StackOverflowException`.
+
+    ```kotlin
+    class NoteView(context: Context) : ContourLayout(context) {
+      val name = TextView(context).layoutBy {
+        text = "Ben Sisko"
+        textSize = 16.sp
+        LayoutSpec(
+          x = leftTo { parent.left() },
+          y = topTo { parent.top() }
+        )
+      }
+    }
+    ```
 
 ## Version 0.1.7
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Compose is a programmatic UI toolkit that uses reactive programming to drive the
 ### Contour is *not* Anko:
 Anko is JetBrain’s typesafe builder library for Android. It introduces none of its own layout logic, but provides convenience builders for the existing Android views and layouts. In contrast Contour provides its own layout mechanism - and actually discourages highly nested view hierarchies because it turns out they are [kinda problematic](https://developer.android.com/topic/performance/rendering/optimizing-view-hierarchies)
 
-## What Contour Is: 
+## What Contour Is:
 Contour aims to be the thinnest possible wrapper around Android’s layout APIs. It allows you to build compound views in pure Kotlin without using opaque layout rules - but instead by hooking into the layout phase yourself. The best comparison for Contour would be to ConstraintLayout - but instead of defining constraints in XML you actually provide them as executable lambdas.
 
 Also - on the topic of XML layouts ...
@@ -37,22 +37,22 @@ Let's create a simple note-taking view that displays a username aligned to the l
 ```kotlin
 class NoteView(context: Context) : ContourLayout(context) {
   private val name: TextView =
-    TextView(context).apply {
+    TextView(context).layoutBy {
       text = "Ben Sisko"
       setTextColor(White)
       setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18f)
-      applyLayout(
+      LayoutSpec(
         x = leftTo { parent.left() + 15.dip },
         y = topTo { parent.top() + 15.dip }
       )
     }
 
   private val note =
-    TextView(context).apply {
+    TextView(context).layoutBy {
       text = siskoWisdom
       setTextColor(White)
       setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14f)
-      applyLayout(
+      LayoutSpec(
         x = leftTo { name.right() + 15.dip }
           .rightTo { parent.right() - 15.dip },
         y = topTo { parent.top() + 15.dip }
@@ -73,12 +73,12 @@ Let's also introduce an avatar, and have its width and height match the width of
 
 ```kotlin
   private val avatar =
-    AvatarImageView(context).apply {
+    AvatarImageView(context).layoutBy {
       scaleType = ImageView.ScaleType.CENTER_CROP
       Picasso.get()
         .load("https://upload.wikimedia.org/wikipedia/en/9/92/BenSisko.jpg")
         .into(this)
-      applyLayout(
+      LayoutSpec(
         x = leftTo { name.left() }
           .widthOf { name.width() },
         y = topTo { name.bottom() }
@@ -90,11 +90,11 @@ Let's also introduce an avatar, and have its width and height match the width of
 Finally, let's insert a created date between the note content and the bottom of the view. If there is not enough content in the `note: TextView`, let's align the created date vertically with the name & icon.
 
 ```kotlin
-  private val starDate = TextView(context).apply {
+  private val starDate = TextView(context).layoutBy {
     text = "Stardate: 23634.1"
     setTextColor(White)
     setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18f)
-    applyLayout(
+    LayoutSpec(
       x = rightTo { parent.right() - 15.dip },
       y = maxOf(
         topTo { note.bottom() + 5.dip },
@@ -119,12 +119,12 @@ This offers a couple advantages:
 Since configuration is simply provided through lambdas, you can make runtime layout decisions.
 For example:
 ```kotlin
-leftTo { 
+leftTo {
   if (user.name.isEmpty) parent.left()
   else nameView.right()
 }
 ```
-Or 
+Or
 ```kotlin
 heightOf {
   maxOf(note.height(), 100.dip)
@@ -147,7 +147,7 @@ Contour tries to make it easy to do the right thing. As part of this effort, all
 For example, when defining a constraint of `leftTo`, the only exposed methods to chain in this layout are `rightTo` or `widthOf`. Another `leftTo`, or `centerHorizontallyTo` don't really make sense in this context and are hidden.
 In short:
 ```
-applyLayout(
+layoutBy(
   x = leftTo { name.left() }
     .leftTo { name.right() },
   y = topTo { name.bottom() }
@@ -156,13 +156,13 @@ applyLayout(
 Will not compile.
 
 #### Axis Type Safety
-Contour makes heavy use of inline classes to provide axis type safety in layouts. What this means is 
+Contour makes heavy use of inline classes to provide axis type safety in layouts. What this means is
 ```kotlin
 toLeftOf { view.top() }
-``` 
-will not compile. `toLeftOf {}` requires a `XInt`, and `top()` returns a `YInt`. In cases where this needs to be forced, casting functions are made available to `toY()` & `toX()`. 
+```
+will not compile. `toLeftOf {}` requires a `XInt`, and `top()` returns a `YInt`. In cases where this needs to be forced, casting functions are made available to `toY()` & `toX()`.
 
-Inline classes are a lightweight compile-time addition that allow this feature with minimal to no performance costs. 
+Inline classes are a lightweight compile-time addition that allow this feature with minimal to no performance costs.
 https://kotlinlang.org/docs/reference/inline-classes.html
 
 ### Circular Reference Debugging

--- a/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
@@ -27,7 +27,7 @@ class ContourTests {
         width = 200,
         height = 50
     ) {
-      plainOldView.applyLayout(
+      plainOldView.layoutBy(
           leftTo { parent.left() }.rightTo { parent.right() },
           topTo { parent.top() }.bottomTo { parent.bottom() }
       )
@@ -47,14 +47,14 @@ class ContourTests {
         width = 200,
         height = 50
     ) {
-      fakeImageView.applyLayout(
+      fakeImageView.layoutBy(
           leftTo { parent.left() }.widthOf {
             parent.height()
                 .toX()
           },
           topTo { parent.top() }.heightOf { parent.height() }
       )
-      fakeTextView.applyLayout(
+      fakeTextView.layoutBy(
           leftTo { fakeImageView.right() }.rightTo { parent.right() },
           topTo { parent.top() }.heightOf { parent.height() }
       )
@@ -74,7 +74,7 @@ class ContourTests {
     val fakeTextView = FakeTextView(activity, "Test", 10)
 
     contourLayout(activity) {
-      fakeTextView.applyLayout(
+      fakeTextView.layoutBy(
           leftTo { parent.left() },
           topTo { parent.top() }
       )
@@ -93,11 +93,11 @@ class ContourTests {
     val x1 = 20.toXInt()
 
     val layout = contourLayout(activity) {
-      view0.applyLayout(
+      view0.layoutBy(
           maxOf(leftTo { x0 }, leftTo { x1 }),
           topTo { parent.top() }
       )
-      view1.applyLayout(
+      view1.layoutBy(
           minOf(leftTo { x0 }, leftTo { x1 }),
           topTo { parent.top() }
       )
@@ -122,11 +122,11 @@ class ContourTests {
     val y1 = 20.toYInt()
 
     val layout = contourLayout(activity) {
-      view0.applyLayout(
+      view0.layoutBy(
           leftTo { parent.left() },
           maxOf(topTo { y0 }, topTo { y1 })
       )
-      view1.applyLayout(
+      view1.layoutBy(
           leftTo { parent.left() },
           minOf(topTo { y0 }, topTo { y1 })
       )
@@ -152,7 +152,7 @@ class ContourTests {
         activity,
         width = 50
     ) {
-      view.applyLayout(
+      view.layoutBy(
           leftTo { parent.left() }.widthOfFloat { parent.width() * amount },
           centerVerticallyTo { parent.centerY() }
       )
@@ -175,7 +175,7 @@ class ContourTests {
         activity,
         width = 260
     ) {
-      view.applyLayout(
+      view.layoutBy(
           leftTo { parent.left() }.widthOfFloat { parent.width() * amount },
           centerVerticallyTo { parent.centerY() }
       )
@@ -194,7 +194,7 @@ class ContourTests {
     view.visibility = View.GONE
 
     val layout = contourLayout(activity) {
-      view.applyLayout(
+      view.layoutBy(
           leftTo { parent.centerX() },
           topTo { parent.centerY() }
       )
@@ -225,14 +225,14 @@ class ContourTests {
     val otherView = View(activity)
 
     val layout = contourLayout(activity, width = 200, height = 50) {
-      viewThatIsGone.applyLayout(
+      viewThatIsGone.layoutBy(
           leftTo { parent.centerX() }
               .widthOf { 10.xdip },
           topTo { parent.centerY() }
               .heightOf { 15.ydip }
       )
 
-      otherView.applyLayout(
+      otherView.layoutBy(
           leftTo { parent.left() + 5 }
               .widthOf { viewThatIsGone.width() + 1 },
           topTo { parent.top() + 10 }

--- a/sample-app/src/main/java/com/squareup/contour/sample/SampleView1.kt
+++ b/sample-app/src/main/java/com/squareup/contour/sample/SampleView1.kt
@@ -77,7 +77,7 @@ class SampleView1(context: SampleActivity) : ContourLayout(context) {
   }
 
   override fun onInitializeLayout() {
-    avatar.applyLayout(
+    avatar.layoutBy(
         leftTo {
           parent.left() + 15.dip
         }.widthOf {
@@ -89,11 +89,11 @@ class SampleView1(context: SampleActivity) : ContourLayout(context) {
           name.width().toY()
         }
     )
-    name.applyLayout(
+    name.layoutBy(
         leftTo { avatar.left() },
         topTo { avatar.bottom() + 5.dip }
     )
-    description.applyLayout(
+    description.layoutBy(
         leftTo {
           name.right() + 15.dip
         }.rightTo {
@@ -103,7 +103,7 @@ class SampleView1(context: SampleActivity) : ContourLayout(context) {
           parent.top() + 15.dip
         }
     )
-    starDate.applyLayout(
+    starDate.layoutBy(
         rightTo { parent.right() - 15.dip },
         maxOf(
             topTo { description.bottom() + 5.dip },

--- a/sample-app/src/main/java/com/squareup/contour/sample/SampleView2.kt
+++ b/sample-app/src/main/java/com/squareup/contour/sample/SampleView2.kt
@@ -22,26 +22,42 @@ class SampleView2(context: SampleActivity) : ContourLayout(context) {
   )
 
   private val avatar =
-    AvatarImageView(context).apply {
+    AvatarImageView(context).layoutBy {
       scaleType = ImageView.ScaleType.CENTER_CROP
       Picasso.get()
           .load("https://upload.wikimedia.org/wikipedia/en/9/92/BenSisko.jpg")
           .into(this)
       paint.strokeWidth = 3f.dip
+      LayoutSpec(
+          x = leftTo { parent.left() + 15.dip }.widthOf { 50.xdip },
+          y = topTo { parent.top() + 15.dip }.heightOf { 50.ydip }
+      )
     }
 
-  private val name =
-    TextView(context).apply {
+  private val name: TextView =
+    TextView(context).layoutBy {
       text = "Ben Sisko"
       setSingleLine()
       ellipsize = TruncateAt.END
       setTextColor(White)
       setTextSize(TypedValue.COMPLEX_UNIT_DIP, 24f)
+      LayoutSpec(
+          x = leftTo { avatar.right() + 15.dip }
+              .rightTo(AtMost) { parent.width() - checkmark.width() - 30.dip },
+          y = centerVerticallyTo { parent.centerY() }
+      )
     }
 
   private val checkmark =
-    ImageView(context).apply {
+    ImageView(context).layoutBy {
       setImageResource(R.drawable.check_mark)
+      LayoutSpec(
+          x = minOf(
+              leftTo { name.right() + 15.dip },
+              rightTo { parent.width() - 15.dip }
+          ),
+          y = centerVerticallyTo { name.centerY() }
+      )
     }
 
   init {
@@ -66,35 +82,5 @@ class SampleView2(context: SampleActivity) : ContourLayout(context) {
             .start()
       }
     }
-  }
-
-  override fun onInitializeLayout() {
-    avatar.applyLayout(
-        leftTo {
-          parent.left() + 15.dip
-        }.widthOf {
-          50.xdip
-        },
-        topTo {
-          parent.top() + 15.dip
-        }.heightOf {
-          50.ydip
-        }
-    )
-    name.applyLayout(
-        leftTo {
-          avatar.right() + 15.dip
-        }.rightTo(AtMost) {
-          parent.width() - checkmark.width() - 30.dip
-        },
-        centerVerticallyTo { parent.centerY() }
-    )
-    checkmark.applyLayout(
-        minOf(
-            leftTo { name.right() + 15.dip },
-            rightTo { parent.width() - 15.dip }
-        ),
-        centerVerticallyTo { name.centerY() }
-    )
   }
 }


### PR DESCRIPTION
When working with nested contour views, it's extremely easy to shoot oneself in the foot when using kotlin's `apply{}`. If `applyLayout()` is called on the containing view instead of the child view, the code runs into a `StackOverflowException`. Some more context can be found in #58.

```kotlin
class NoteView(context: Context) : ContourLayout(context) {
  val name = AnotherContourView(context).apply {
    applyLayout(  // CRASH!
      x = leftTo { parent.left() },
      y = topTo { parent.top() }
    )
  }
}

class AnotherContourView(context): ContourLayout(context)
```

After spending some time on this, I've realized that this must be solved in two-parts:

1. Discourage people from using `apply {}` for laying out child views. This PR adds a `layoutBy {}` extension function that should be used instead. `layoutBy {}` requires a return value so it's impossible to run into a scope issue. Usage:

```kotlin
class NoteView(context: Context) : ContourLayout(context) {
  val name = TextView(context).layoutBy {
    text = "Ben Sisko"
    textSize = 16.sp
    LayoutSpec(
      x = leftTo { parent.left() },
      y = topTo { parent.top() }
    )
  }
}
```

We chose `layoutBy()` because it nicely describes what we're doing when building a view: describing how child views are laid out. `applyLayout()` is also deprecated in favor of `layoutBy()`. 

2. Just having a better API doesn't mean people will actually find and use it. In a follow-up PR (#68), I'm adding a lint check that flags `layoutBy()` calls on the wrong receiver along with also offers a quick-fix for converting `apply { layoutBy() }` to `layoutBy { LayoutSpec() }`.

Fixes #58  