### PR TITLE
Add a lint check for catching layout() calls in the wrong place

### DIFF
--- a/contour-lint/build.gradle
+++ b/contour-lint/build.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8
+
+dependencies {
+  def lintVersion = "27.0.0"
+  compileOnly "com.android.tools.lint:lint-api:$lintVersion"
+  compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
+  testImplementation "com.android.tools.lint:lint:$lintVersion"
+  testImplementation "com.android.tools.lint:lint-tests:$lintVersion"
+}
+
+jar {
+  manifest {
+    attributes('Lint-Registry-v2': 'com.squareup.contour.lint.ContourIssueRegistry')
+  }
+}

--- a/contour-lint/src/main/java/com/squareup/contour/lint/Collections.ext.kt
+++ b/contour-lint/src/main/java/com/squareup/contour/lint/Collections.ext.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.contour.lint
+
+/** Reorders items in `indices` to `to`. */
+internal fun <E> List<E>.reorder(indices: IntRange, to: Int): List<E> {
+  return sortedByIndex { index ->
+    when (index) {
+      to -> 2
+      in indices -> 1
+      else -> 0
+    }
+  }
+}
+
+internal inline fun <E, R> List<E>.sortedByIndex(crossinline selector: (i: Int) -> R): List<E> where R : Comparable<R> {
+  return mapIndexed { i, item -> i to item }
+      .sortedBy { (i) -> selector(i) }
+      .map { (_, item) -> item }
+}
+
+/** Like split("\n"), but doesn't throw away trailing line breaks. */
+internal fun String.splitLines(): MutableList<String> {
+  return split("\n").map { it + "\n" }.toMutableList().apply {
+    mapAt(lastIndex) { it.dropLast(1) }  // drop extra '\n'.
+  }
+}
+
+/** Modifies an item at [index] in place. */
+internal fun <E> MutableList<E>.mapAt(index: Int, run: (E) -> E): MutableList<E> {
+  this[index] = run(this[index])
+  return this
+}

--- a/contour-lint/src/main/java/com/squareup/contour/lint/ContourIssueRegistry.kt
+++ b/contour-lint/src/main/java/com/squareup/contour/lint/ContourIssueRegistry.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.contour.lint
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
+import com.android.tools.lint.detector.api.Issue
+
+@Suppress("UnstableApiUsage", "unused")
+class ContourIssueRegistry : IssueRegistry() {
+  override val issues: List<Issue>
+    get() = listOf(NestedContourLayoutsDetector.ISSUE)
+
+  override val api: Int
+    get() = CURRENT_API
+}

--- a/contour-lint/src/main/java/com/squareup/contour/lint/NestedContourLayoutsDetector.kt
+++ b/contour-lint/src/main/java/com/squareup/contour/lint/NestedContourLayoutsDetector.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.contour.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiType
+import org.jetbrains.kotlin.psi.psiUtil.getStartOffsetIn
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.ULambdaExpression
+import org.jetbrains.uast.getContainingUClass
+import org.jetbrains.uast.getParentOfType
+import org.jetbrains.uast.getUCallExpression
+
+@Suppress("UnstableApiUsage")
+class NestedContourLayoutsDetector : Detector(), Detector.UastScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> =
+    listOf(UCallExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      override fun visitCallExpression(node: UCallExpression) {
+        if (isContourLayoutFunction(node)) {
+          check(context, node)
+        }
+      }
+    }
+  }
+
+  private fun isContourLayoutFunction(node: UCallExpression): Boolean {
+    if (node.methodName != "layoutBy" && node.methodName != "applyLayout") return false
+    if (node.valueArgumentCount < 2) return false
+
+    // Type resolution for kotlin classes doesn't work when lint
+    // is run from the command line so node.resolve() will be null.
+    val function = node.resolve()
+    if (function == null) {
+      // Skip the 0th param, which will be the type param (<T>).
+      val argType = { at: Int -> node.getArgumentForParameter(at)?.getExpressionType() }
+      return isAxisSolver(argType(1)) && isAxisSolver(argType(2))
+
+    } else if (function.containingClass?.qualifiedName == "com.squareup.contour.ContourLayout") {
+      val params = function.parameters
+      return params[1]?.name == "x" && params[2]?.name == "y"
+    }
+    return false
+  }
+
+  private fun isAxisSolver(type: PsiType?): Boolean {
+    if (type == null) return false
+    if (type.canonicalText == "com.squareup.contour.solvers.AxisSolver") return true
+    for (superT in type.superTypes) {
+      if (isAxisSolver(superT)) return true
+    }
+    return false
+  }
+
+  private fun check(context: JavaContext, node: UCallExpression) {
+    val isInsideLambda = node.getParentOfType<ULambdaExpression>() != null
+    val isInsideContourView = isContourView(context, node.getContainingUClass())
+    if (!isInsideLambda || !isInsideContourView) {
+      return
+    }
+
+    val layoutReceiverView = (node.getUCallExpression()?.receiverType as? PsiClassType)?.resolve()
+    val containingView = node.getContainingUClass()!!
+
+    if (!containingView.isEquivalentTo(layoutReceiverView)) {
+      // Code example:
+      // class BarView : ContourLayout
+      // class FooView : ContourLayout {
+      //   val view = BarView(context).apply {
+      //     layout(x, y) <- ERROR! The receiver of this layout() call isn't FooView.
+      //   }
+      // }
+      val nestedContourView = layoutReceiverView?.name
+      val quickFix = maybeGenerateFix(context, node)
+      context.report(
+          issue = ISSUE,
+          scope = node,
+          location = context.getNameLocation(node),
+          quickfixData = quickFix,
+          message = "Calling `${node.methodName}(x,y)` on a nested contour view " +
+              "(`$nestedContourView`) here is an error.\n Prefer using " +
+              "`$nestedContourView.layoutBy { LayoutSpec(x,y) }` instead."
+      )
+    }
+  }
+
+  private fun isContourView(context: JavaContext, type: PsiClass?): Boolean {
+    return context.evaluator.extendsClass(type, "com.squareup.contour.ContourLayout", true)
+  }
+
+  private fun maybeGenerateFix(context: JavaContext, layoutCall: UCallExpression): LintFix? {
+    val lambdaCall = layoutCall.getParentOfType<UCallExpression>()
+    if (layoutCall.sourcePsi == null || lambdaCall?.sourcePsi == null) return null
+
+    val lambdaCallName = lambdaCall.methodName    // e.g., "apply", "run"
+    val layoutCallName = layoutCall.methodName    // e.g., "layout", "applyLayout"
+
+    val lambdaText = lambdaCall.sourcePsi!!.text
+    if (lambdaText.indexOf("$layoutCallName(") != lambdaText.lastIndexOf("$layoutCallName(")) {
+      // Multiple calls to layout(); possibly too complex to auto-fix.
+      return null
+    }
+
+    val lambdaLines = lambdaText.splitLines()
+    if (lambdaLines.last().trim() != "}") {
+      // Unformatted code?
+      return null
+    }
+    if (lambdaLines[0].trim().let { it != "$lambdaCallName {" && it != "$lambdaCallName{" }) {
+      // Function call or the lambda has parameters e.g., with(FooView()).
+      return null
+    }
+
+    val layoutOffsets = layoutCall.textOffsetsIn(lambdaCall)
+    val layoutLineNums = IntRange(
+        lineNumForOffset(lambdaLines, layoutOffsets.first),
+        lineNumForOffset(lambdaLines, layoutOffsets.last)
+    )
+
+    // Reorder lines to handle cases where layout() isn't present on the last line.
+    val fixed = lambdaLines
+        .mapAt(0) { it.replace(lambdaCall.methodName!!, "layoutBy") }
+        .mapAt(layoutLineNums.first) { it.replace("$layoutCallName(", "LayoutSpec(") }
+        .reorder(layoutLineNums, to = lambdaLines.size - 1)
+        .joinToString(separator = "")
+
+    return LintFix.create()
+        .replace()
+        .text(lambdaText)
+        .with(fixed)
+        .name("Use layoutBy { LayoutSpec(x, y) } instead")
+        .range(context.getLocation(lambdaCall))
+        .independent(true)
+        .reformat(true)
+        .build()
+  }
+
+  private fun lineNumForOffset(lines: List<String>, index: Int): Int {
+    var lengthSeen = 0
+    for ((num, line) in lines.withIndex()) {
+      lengthSeen += line.length
+      if (index <= lengthSeen) {
+        return num
+      }
+    }
+    error("Offset $index not in $lines")
+  }
+
+  private fun UCallExpression.textOffsetsIn(ancestor: UElement): IntRange {
+    val start = sourcePsi!!.getStartOffsetIn(ancestor.sourcePsi!!)
+    val end = start + sourcePsi!!.textLength
+    return start..end
+  }
+
+  companion object {
+    val ISSUE = Issue.create(
+        id = "NestedContourLayouts",
+        briefDescription = "Incorrectly nested ContourLayouts",
+        explanation = """
+          When a nested contour view is initialized and laid out using a lambda that offers \
+          `this` as an argument (e.g., Kotlin's `apply{}` and `run{}`), it's easy to accidentally \
+          call `layoutBy()`/`applyLayout()` on the wrong scope. This lint flags these kinds of \
+          errors. Here's an example:
+          
+          ```
+          class FooView : ContourLayout {
+            val view = BarView(context).apply {
+              layoutBy(x, y) <- ERROR! The receiver of this call is BarView and not FooView!
+            }
+          }
+          class BarView(context: Context) : ContourLayout
+          ```
+          
+          The above example result in a StackOverflowException because `FooView` ends up laying \ 
+          out itself rather than `BarView`.
+        """.trimMargin(),
+        category = Category.CORRECTNESS,
+        severity = ERROR,
+        priority = 5,
+        implementation = Implementation(
+            NestedContourLayoutsDetector::class.java,
+            Scope.JAVA_FILE_SCOPE
+        )
+    )
+  }
+}

--- a/contour-lint/src/test/java/com/squareup/contour/lint/NestedContourLayoutsDetectorTest.kt
+++ b/contour-lint/src/test/java/com/squareup/contour/lint/NestedContourLayoutsDetectorTest.kt
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.contour.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.java
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.kotlin
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runners.MethodSorters.JVM
+
+@Suppress("UnstableApiUsage")
+@FixMethodOrder(JVM)
+class NestedContourLayoutsDetectorTest {
+
+  private fun lint(source: TestFile): TestLintTask {
+    return TestLintTask.lint().files(
+        VIEW_STUB,
+        AXIS_SOLVERS_STUB,
+        CONTOUR_LAYOUT_STUB,
+        source
+    )
+  }
+
+  @Test fun `nested contour views with layoutBy{} are okay`() {
+    val source = """
+      |package sample
+      |
+      |import android.content.Context
+      |import com.squareup.contour.ContourLayout
+      |
+      |class FooView(context: Context) : ContourLayout(context) {
+      |  private val view1 = BarView(context).layoutBy {
+      |    LayoutSpec(
+      |        x = matchParentX(),
+      |        y = matchParentY()
+      |    )
+      |  } 
+      |}
+      |
+      |class BarView(context: Context) : ContourLayout(context)              
+      """.trimMargin()
+
+    lint(kotlin(source))
+        .issues(NestedContourLayoutsDetector.ISSUE)
+        .run()
+        .expectClean()
+  }
+
+  @Test fun `nested contour views with 'this' as the receiver`() {
+    val source = """
+      |package sample
+      |
+      |import android.content.Context
+      |import com.squareup.contour.ContourLayout
+      |
+      |class FooView(context: Context) : ContourLayout(context) {
+      |  private val view1 = BarView(context).apply {
+      |    layoutBy(
+      |        x = matchParentX(),
+      |        y = matchParentY()
+      |    )
+      |  }
+      |  private val view2 = with(BarView(context)) {
+      |    layoutBy(
+      |        x = matchParentX(),
+      |        y = matchParentY()
+      |    )
+      |  }
+      |  private val view3 = BarView(context).run {
+      |    applyLayout(
+      |        x = matchParentX(),
+      |        y = matchParentY()
+      |    )
+      |  }
+      |}
+      |
+      |class BarView(context: Context) : ContourLayout(context)              
+      """.trimMargin()
+
+    lint(kotlin(source))
+        .issues(NestedContourLayoutsDetector.ISSUE)
+        .run()
+        .expect(
+            """
+            |src/sample/FooView.kt:8: Error: Calling layoutBy(x,y) on a nested contour view (BarView) here is an error.
+            | Prefer using BarView.layoutBy { LayoutSpec(x,y) } instead. [NestedContourLayouts]
+            |    layoutBy(
+            |    ~~~~~~~~
+            |src/sample/FooView.kt:14: Error: Calling layoutBy(x,y) on a nested contour view (BarView) here is an error.
+            | Prefer using BarView.layoutBy { LayoutSpec(x,y) } instead. [NestedContourLayouts]
+            |    layoutBy(
+            |    ~~~~~~~~
+            |src/sample/FooView.kt:20: Error: Calling applyLayout(x,y) on a nested contour view (BarView) here is an error.
+            | Prefer using BarView.layoutBy { LayoutSpec(x,y) } instead. [NestedContourLayouts]
+            |    applyLayout(
+            |    ~~~~~~~~~~~
+            |3 errors, 0 warnings
+            """.trimMargin()
+        )
+  }
+
+  @Test fun `nested contour views with 'this' as the argument`() {
+    val source = """
+      |package sample
+      |
+      |import android.content.Context
+      |import com.squareup.contour.ContourLayout
+      |
+      |class FooView(context: Context) : ContourLayout(context) {
+      |  private val view1 = BarView(context).let {
+      |    layoutBy(
+      |        x = leftTo { parent.left() },
+      |        y = topTo { parent.top() }
+      |    )
+      |  }
+      |  
+      |  private val view2 = BarView(context).also {
+      |    layoutBy(
+      |        x = rightTo { parent.right() },
+      |        y = bottomTo { parent.bottom() }
+      |    )
+      |  }
+      |}
+      |
+      |class BarView(context: Context) : ContourLayout(context)              
+      """.trimMargin()
+
+    lint(kotlin(source))
+        .issues(NestedContourLayoutsDetector.ISSUE)
+        .run()
+        .expectClean()
+  }
+
+  @Test fun `nested non-contour views`() {
+    val source = """
+      |package sample
+      |
+      |import android.content.Context
+      |import android.view.View
+      |import com.squareup.contour.ContourLayout
+      |
+      |class FooView(context: Context) : ContourLayout(context) {
+      |  private val view = View(context).apply {
+      |    layoutBy(
+      |        x = leftTo { parent.left() },
+      |        y = bottomTo { parent.bottom() }
+      |    )
+      |  }
+      |}
+      """.trimMargin()
+
+    lint(kotlin(source))
+        .issues(NestedContourLayoutsDetector.ISSUE)
+        .run()
+        .expectClean()
+  }
+
+  @Test fun `calling layoutBy outside a lambda`() {
+    val source = """
+      |package sample
+      |
+      |import android.content.Context
+      |import android.view.View
+      |import com.squareup.contour.ContourLayout
+      |
+      |class FooView(context: Context) : ContourLayout(context) {
+      |  private val view1 = View(context)
+      |  private val view2 = BarView(context)
+      | 
+      | override fun onInitializeLayout() {
+      |    view1.layoutBy(
+      |        x = leftTo { parent.left() },
+      |        y = topTo { parent.top() }
+      |    )
+      |
+      |    view2.layoutBy(
+      |        x = rightTo { parent.right() },
+      |        y = bottomTo { parent.bottom() }
+      |    )
+      |  }
+      |}
+      |
+      |class BarView(context: Context) : ContourLayout(context)
+      """.trimMargin()
+
+    lint(kotlin(source))
+        .issues(NestedContourLayoutsDetector.ISSUE)
+        .run()
+        .expectClean()
+  }
+
+  @Test fun `nested contour views with complex class hierarchy`() {
+    val source = """
+      |package sample
+      |
+      |import android.content.Context
+      |import com.squareup.contour.ContourLayout
+      |
+      |class FooView(context: Context) : OnClickListener, ContourLayout(context) {
+      |  private val view = BarBarView(context).apply {
+      |    layoutBy(
+      |        x = matchParentX(),
+      |        y = matchParentY()
+      |    )
+      |  }
+      |}
+      |
+      |class BarBarView(context: Context) : OnClickListener, BarView(context)    
+      |open class BarView(context: Context) : ContourLayout(context)
+      |interface OnClickListener
+      """.trimMargin()
+
+    lint(kotlin(source))
+        .issues(NestedContourLayoutsDetector.ISSUE)
+        .run()
+        .expectErrorCount(1)
+  }
+
+  @Test fun `generate fix for simple cases`() {
+    val source = """
+      |package sample
+      |
+      |import android.content.Context
+      |import com.squareup.contour.ContourLayout
+      |
+      |class FooView(context: Context) : ContourLayout(context) {
+      |  private val view1 = BarView(context).apply {
+      |    textSize = 1f
+      |    textColor = "#FFFFFF"
+      |    layoutBy(
+      |        x = matchParentX(),
+      |        y = matchParentY()
+      |    )
+      |    setBackgroundColor("#000000")
+      |  }
+      |}
+      |
+      |class BarView(context: Context) : ContourLayout(context)
+      """.trimMargin()
+
+    lint(kotlin(source))
+        .issues(NestedContourLayoutsDetector.ISSUE)
+        .run()
+        .checkFix(
+            fix = null,
+            after = kotlin(
+                """
+                |package sample
+                |
+                |import android.content.Context
+                |import com.squareup.contour.ContourLayout
+                |
+                |class FooView(context: Context) : ContourLayout(context) {
+                |  private val view1 = BarView(context).layoutBy {
+                |    textSize = 1f
+                |    textColor = "#FFFFFF"
+                |    setBackgroundColor("#000000")
+                |    LayoutSpec(
+                |        x = matchParentX(),
+                |        y = matchParentY()
+                |    )
+                |  }
+                |}
+                |
+                |class BarView(context: Context) : ContourLayout(context)
+                """.trimMargin()
+            )
+        )
+  }
+
+  @Test fun `avoid generation of fix for complex cases`() {
+    val source = """
+      |package sample
+      |
+      |import android.content.Context
+      |import com.squareup.contour.ContourLayout
+      |
+      |class FooView(context: Context) : ContourLayout(context) {
+      |  private val view1 = BarView(context).apply { param ->
+      |    layoutBy(
+      |        x = matchParentX(),
+      |        y = matchParentY()
+      |    )
+      |  }
+      |  private val view2 = with(BarView(context)) {
+      |    layoutBy(
+      |        x = matchParentX(),
+      |        y = matchParentY()
+      |    )
+      |  }
+      |}
+      |
+      |class BarView(context: Context) : ContourLayout(context)
+      """.trimMargin()
+
+    lint(kotlin(source))
+        .issues(NestedContourLayoutsDetector.ISSUE)
+        .run()
+        .checkFix(
+            fix = null,
+            after = kotlin(source)
+        )
+  }
+
+  companion object {
+    private val AXIS_SOLVERS_STUB = kotlin(
+        """
+        |package com.squareup.contour.solvers
+        |
+        |interface AxisSolver
+        |interface XAxisSolver : AxisSolver
+        |interface YAxisSolver : AxisSolver
+        """.trimMargin()
+    )
+    private val CONTOUR_LAYOUT_STUB = kotlin(
+        """
+        |package com.squareup.contour
+        |
+        |import android.content.Context
+        |import android.view.View
+        |import android.view.ViewGroup
+        |import com.squareup.contour.solvers.XAxisSolver
+        |import com.squareup.contour.solvers.YAxisSolver
+        |
+        |open class ContourLayout(context: Context) : ViewGroup(context) {
+        |  fun View.layoutBy(x: XAxisSolver, y: YAxisSolver): Unit = TODO()
+        |  fun <T> T.layoutBy(addToViewGroup: Boolean, spec: T.() -> LayoutSpec): T = TODO()
+        |  fun <T> T.applyLayout(x: XAxisSolver, y: YAxisSolver): T = TODO()
+        |}
+        """.trimMargin()
+    )
+    private val VIEW_STUB = java(
+        """
+        |package android.view;
+        |
+        |import android.content.Context;
+        |
+        |public class View {
+        |  public View(Context context) {}
+        |}
+        """.trimMargin()
+    )
+  }
+}

--- a/contour/build.gradle
+++ b/contour/build.gradle
@@ -22,6 +22,8 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
   testImplementation "com.google.truth:truth:1.0.1"
   testImplementation 'org.robolectric:robolectric:4.3.1'
+
+  lintPublish project(':contour-lint')
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'contour-parent'
 
 include ':contour'
+include ':contour-lint'
 include ':sample-app'


### PR DESCRIPTION
Follow up of #67. This PR adds a lint check to catch calls to `applyLayout()`/`layout()` made on the wrong receiver type, that will result in a runtime exception and offers a fix to use the new `layout {}` function.

The lint fix is only generated for `apply {}` lambdas. 

![lint](https://user-images.githubusercontent.com/2387680/84554120-7a253080-ace4-11ea-889e-e3f008921844.gif)
