### PR TITLE
Add new ContourLayout sizing utilities for wrap_content and match_parent

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -24,6 +24,10 @@ import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
 import com.squareup.contour.constraints.SizeConfig
+import com.squareup.contour.constraints.SizeConfigSmartLambdas.CoordinateAxis.HORIZONTAL
+import com.squareup.contour.constraints.SizeConfigSmartLambdas.CoordinateAxis.VERTICAL
+import com.squareup.contour.constraints.SizeConfigSmartLambdas.matchParent
+import com.squareup.contour.constraints.SizeConfigSmartLambdas.wrapContent
 import com.squareup.contour.errors.CircularReferenceDetected
 import com.squareup.contour.solvers.AxisSolver
 import com.squareup.contour.solvers.ComparisonResolver
@@ -156,8 +160,8 @@ open class ContourLayout(
 ) : ViewGroup(context, attrs) {
 
   private val density: Float = context.resources.displayMetrics.density
-  private val widthConfig = SizeConfig()
-  private val heightConfig = SizeConfig()
+  private val widthConfig = SizeConfig(lambda = matchParent())
+  private val heightConfig = SizeConfig(lambda = matchParent())
   private val geometry = ParentGeometry(
       widthConfig = widthConfig,
       heightConfig = heightConfig,
@@ -295,8 +299,16 @@ open class ContourLayout(
   }
 
   /**
-   * Overrides how the [ContourLayout] should size it's width. By default [ContourLayout] will take all the available
-   * space it is given.
+   * Overrides how the [ContourLayout] should size its width by reverting to the default behaviour, which
+   * is to take all the available space it is given
+   */
+  fun contourWidthMatchParent() {
+    widthConfig.lambda = matchParent()
+  }
+
+  /**
+   * Overrides how the [ContourLayout] should size its width. By default [ContourLayout] will take all the available
+   * space it is given. This override allows fine grained control over the resulting final measure.
    * @param config a function that takes a [XInt] - which is the available space supplied by the [ContourLayout]'s
    * parent - and returns a [XInt] describing how wide the [ContourLayout] should be.
    *
@@ -308,8 +320,24 @@ open class ContourLayout(
   }
 
   /**
-   * Overrides how the [ContourLayout] should size it's height. By default [ContourLayout] will take all the available
-   * space it is given.
+   * Overrides how the [ContourLayout] should size its width. This override instructs the view to take up
+   * as much space as necessary to wrap its subviews, including its own padding.
+   */
+  fun contourWidthWrapContent() {
+    widthConfig.lambda = wrapContent(this, HORIZONTAL)
+  }
+
+  /**
+   * Overrides how the [ContourLayout] should size its height by reverting to the default behaviour, which
+   * is to take all the available space it is given
+   */
+  fun contourHeightMatchParent() {
+    heightConfig.lambda = matchParent()
+  }
+
+  /**
+   * Overrides how the [ContourLayout] should size its height. By default [ContourLayout] will take all the available
+   * space it is given. This override allows fine grained control over the resulting final measure.
    * @param config a function that takes a [YInt] - which is the available space supplied by the [ContourLayout]'s
    * parent - and returns a [YInt] describing how tall the [ContourLayout] should be.
    *
@@ -318,6 +346,14 @@ open class ContourLayout(
    */
   fun contourHeightOf(config: (available: YInt) -> YInt) {
     heightConfig.lambda = unwrapYIntToYIntLambda(config)
+  }
+
+  /**
+   * Overrides how the [ContourLayout] should size its height. This override instructs the view to take up
+   * as much space as necessary to wrap its subviews, including its own padding.
+   */
+  fun contourHeightWrapContent() {
+    heightConfig.lambda = wrapContent(this, VERTICAL)
   }
 
   /**

--- a/contour/src/main/kotlin/com/squareup/contour/constraints/SizeConfig.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/constraints/SizeConfig.kt
@@ -16,10 +16,12 @@
 
 package com.squareup.contour.constraints
 
-internal class SizeConfig {
-  var available: Int = Int.MIN_VALUE
-  var result: Int = Int.MIN_VALUE
-  var lambda: (Int) -> Int = { it }
+internal typealias SizeConfigLambda = (available: Int) -> Int
+internal class SizeConfig(
+  var available: Int = Int.MIN_VALUE,
+  var result: Int = Int.MIN_VALUE,
+  var lambda: SizeConfigLambda
+) {
 
   fun resolve(): Int {
     if (result == Int.MIN_VALUE) {

--- a/contour/src/main/kotlin/com/squareup/contour/constraints/SizeConfigSmartLambdas.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/constraints/SizeConfigSmartLambdas.kt
@@ -1,0 +1,35 @@
+package com.squareup.contour.constraints
+
+import android.view.View
+import com.squareup.contour.ContourLayout
+import com.squareup.contour.constraints.SizeConfigSmartLambdas.CoordinateAxis.HORIZONTAL
+import com.squareup.contour.constraints.SizeConfigSmartLambdas.CoordinateAxis.VERTICAL
+import com.squareup.contour.utils.children
+import kotlin.math.max
+
+internal object SizeConfigSmartLambdas {
+  fun matchParent(): SizeConfigLambda = { it }
+  fun wrapContent(view: ContourLayout, axis: CoordinateAxis): SizeConfigLambda = {
+    view.run {
+      children
+          .filter { it.visibility != View.GONE }
+          .map {
+            when (axis) {
+              VERTICAL -> max(it.bottom().value, paddingTop) + paddingBottom
+              HORIZONTAL -> max(it.right().value, paddingLeft) + paddingRight
+            }
+          }
+          .max() ?: totalPadding(axis)
+    }
+  }
+
+  private fun ContourLayout.totalPadding(axis: CoordinateAxis) = when (axis) {
+    VERTICAL -> paddingTop + paddingBottom
+    HORIZONTAL -> paddingLeft + paddingRight
+  }
+
+  enum class CoordinateAxis {
+    VERTICAL,
+    HORIZONTAL
+  }
+}

--- a/contour/src/main/kotlin/com/squareup/contour/utils/ViewGroups.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/utils/ViewGroups.kt
@@ -1,0 +1,24 @@
+package com.squareup.contour.utils
+
+import android.view.View
+import android.view.ViewGroup
+
+/**
+ * Returns a [MutableIterator] over the views in this view group.
+ * @note @carranca: This was pulled from ktx 1.3.0 so the whole lib didn't have to get pulled in.
+ * */
+operator fun ViewGroup.iterator() = object : MutableIterator<View> {
+  private var index = 0
+  override fun hasNext() = index < childCount
+  override fun next() = getChildAt(index++) ?: throw IndexOutOfBoundsException()
+  override fun remove() = removeViewAt(--index)
+}
+
+/**
+ * Returns a [Sequence] over the child views in this view group.
+ * @note @carranca: This was pulled from ktx 1.3.0 so the whole lib didn't have to get pulled in.
+ * */
+val ViewGroup.children: Sequence<View>
+  get() = object : Sequence<View> {
+    override fun iterator() = this@children.iterator()
+  }

--- a/contour/src/main/kotlin/com/squareup/contour/utils/XYIntUtils.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/utils/XYIntUtils.kt
@@ -23,15 +23,16 @@ import com.squareup.contour.XFloat
 import com.squareup.contour.XInt
 import com.squareup.contour.YFloat
 import com.squareup.contour.YInt
+import com.squareup.contour.constraints.SizeConfigLambda
 
 internal inline fun unwrapXIntToXIntLambda(
   crossinline lambda: (XInt) -> XInt
-): (Int) -> Int =
+): SizeConfigLambda =
   { lambda(it.toXInt()).value }
 
 internal inline fun unwrapYIntToYIntLambda(
   crossinline lambda: (YInt) -> YInt
-): (Int) -> Int =
+): SizeConfigLambda =
   { lambda(it.toYInt()).value }
 
 internal inline fun unwrapXIntLambda(

--- a/contour/src/test/kotlin/com/squareup/contour/ContourSizeConfigTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourSizeConfigTests.kt
@@ -1,0 +1,236 @@
+package com.squareup.contour
+
+import android.app.Activity
+import android.view.View
+import android.view.View.GONE
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
+import com.google.common.truth.Truth.assertThat
+import com.squareup.contour.utils.contourLayout
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ContourSizeConfigTests {
+  private val activity = Robolectric.buildActivity(Activity::class.java).get()
+
+  @Test
+  fun `match parent size config, no subviews`() {
+    val layout = contourLayout(
+        context = activity,
+        width = 200,
+        height = 50
+    ) {
+      setPadding(1, 2, 4, 8)
+      contourWidthMatchParent()
+      contourHeightMatchParent()
+    }
+
+    assertThat(layout.left).isEqualTo(0)
+    assertThat(layout.top).isEqualTo(0)
+    assertThat(layout.right).isEqualTo(200)
+    assertThat(layout.bottom).isEqualTo(50)
+    assertThat(layout.width).isEqualTo(200)
+    assertThat(layout.height).isEqualTo(50)
+  }
+
+  @Test
+  fun `match parent size config, multiple subviews`() {
+    val view1 = View(activity).apply {
+      visibility = VISIBLE
+    }
+    val view2 = View(activity).apply {
+      visibility = VISIBLE
+    }
+    val layout = contourLayout(
+        context = activity,
+        width = 200,
+        height = 50
+    ) {
+      setPadding(1, 2, 4, 8)
+      contourWidthMatchParent()
+      contourHeightMatchParent()
+
+      view1.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 100.toXInt() },
+          y = topTo { parent.top() }.heightOf { 25.toYInt() }
+      )
+
+      view2.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 201.toXInt() },
+          y = topTo { parent.top() }.heightOf { 51.toYInt() }
+      )
+    }
+
+    assertThat(layout.left).isEqualTo(0)
+    assertThat(layout.top).isEqualTo(0)
+    assertThat(layout.right).isEqualTo(200)
+    assertThat(layout.bottom).isEqualTo(50)
+    assertThat(layout.width).isEqualTo(200)
+    assertThat(layout.height).isEqualTo(50)
+  }
+
+  @Test
+  fun `wrap content size config, no subviews`() {
+    val paddingLeft = 1
+    val paddingTop = 2
+    val paddingRight = 4
+    val paddingBottom = 8
+    val layout = contourLayout(
+        context = activity,
+        width = 200,
+        height = 50
+    ) {
+      setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+      contourWidthWrapContent()
+      contourHeightWrapContent()
+    }
+
+    assertThat(layout.left).isEqualTo(0)
+    assertThat(layout.top).isEqualTo(0)
+    assertThat(layout.right).isEqualTo(paddingLeft + paddingRight)
+    assertThat(layout.bottom).isEqualTo(paddingTop + paddingBottom)
+    assertThat(layout.width).isEqualTo(paddingLeft + paddingRight)
+    assertThat(layout.height).isEqualTo(paddingTop + paddingBottom)
+  }
+
+  @Test
+  fun `wrap content size config, multiple subviews`() {
+    val view1 = View(activity).apply {
+      visibility = VISIBLE
+    }
+    val view2 = View(activity).apply {
+      visibility = VISIBLE
+    }
+    val invisibleView = View(activity).apply {
+      visibility = INVISIBLE
+    }
+    val goneView = View(activity).apply {
+      visibility = GONE
+    }
+
+    val paddingLeft = 1
+    val paddingTop = 2
+    val paddingRight = 4
+    val paddingBottom = 8
+    val layout = contourLayout(
+        context = activity,
+        width = 200,
+        height = 50
+    ) {
+      setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+      contourWidthWrapContent()
+      contourHeightWrapContent()
+
+      view1.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 100.toXInt() },
+          y = topTo { parent.top() }.heightOf { 25.toYInt() }
+      )
+
+      view2.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 200.toXInt() },
+          y = topTo { parent.top() }.heightOf { 50.toYInt() }
+      )
+
+      invisibleView.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 300.toXInt() },
+          y = topTo { parent.top() }.heightOf { 60.toYInt() }
+      )
+
+      goneView.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 400.toXInt() },
+          y = topTo { view1.bottom() }.heightOf { 70.toYInt() }
+      )
+    }
+
+    assertThat(layout.left).isEqualTo(0)
+    assertThat(layout.top).isEqualTo(0)
+    assertThat(layout.right).isEqualTo(paddingLeft + 300 + paddingRight)
+    assertThat(layout.bottom).isEqualTo(paddingTop + 60 + paddingBottom)
+    assertThat(layout.width).isEqualTo(paddingLeft + 300 + paddingRight)
+    assertThat(layout.height).isEqualTo(paddingTop + 60 + paddingBottom)
+  }
+
+  @Test
+  fun `exact size config, no subviews`() {
+    val paddingLeft = 1
+    val paddingTop = 2
+    val paddingRight = 4
+    val paddingBottom = 8
+    val layout = contourLayout(
+        context = activity,
+        width = 200,
+        height = 50
+    ) {
+      setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+      contourWidthOf { 16.toXInt() }
+      contourHeightOf { 32.toYInt() }
+    }
+
+    assertThat(layout.left).isEqualTo(0)
+    assertThat(layout.top).isEqualTo(0)
+    assertThat(layout.right).isEqualTo(16)
+    assertThat(layout.bottom).isEqualTo(32)
+    assertThat(layout.width).isEqualTo(16)
+    assertThat(layout.height).isEqualTo(32)
+  }
+
+  @Test
+  fun `exact size config, multiple subviews`() {
+    val view1 = View(activity).apply {
+      visibility = VISIBLE
+    }
+    val view2 = View(activity).apply {
+      visibility = VISIBLE
+    }
+    val invisibleView = View(activity).apply {
+      visibility = INVISIBLE
+    }
+    val goneView = View(activity).apply {
+      visibility = GONE
+    }
+
+    val paddingLeft = 1
+    val paddingTop = 2
+    val paddingRight = 4
+    val paddingBottom = 8
+    val layout = contourLayout(
+        context = activity,
+        width = 200,
+        height = 50
+    ) {
+      setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+      contourWidthOf { 16.toXInt() }
+      contourHeightOf { 32.toYInt() }
+
+      view1.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 100.toXInt() },
+          y = topTo { parent.top() }.heightOf { 25.toYInt() }
+      )
+
+      view2.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 200.toXInt() },
+          y = topTo { parent.top() }.heightOf { 50.toYInt() }
+      )
+
+      invisibleView.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 300.toXInt() },
+          y = topTo { parent.top() }.heightOf { 60.toYInt() }
+      )
+
+      goneView.layoutBy(
+          x = leftTo { parent.left() }.widthOf { 400.toXInt() },
+          y = topTo { view1.bottom() }.heightOf { 70.toYInt() }
+      )
+    }
+
+    assertThat(layout.left).isEqualTo(0)
+    assertThat(layout.top).isEqualTo(0)
+    assertThat(layout.right).isEqualTo(16)
+    assertThat(layout.bottom).isEqualTo(32)
+    assertThat(layout.width).isEqualTo(16)
+    assertThat(layout.height).isEqualTo(32)
+  }
+}

--- a/sample-app/src/main/java/com/squareup/contour/sample/SampleView1.kt
+++ b/sample-app/src/main/java/com/squareup/contour/sample/SampleView1.kt
@@ -60,7 +60,7 @@ class SampleView1(context: SampleActivity) : ContourLayout(context) {
   }
 
   init {
-    contourHeightOf { paddingAdjusterWidget.bottom() + paddingBottom }
+    contourHeightWrapContent()
 
     setBackgroundColor(Blue)
     var animated = false


### PR DESCRIPTION
All screenshots include maximum padding on all dimensions to demonstrate.

[contourHeightMatchParent, view collapsed](https://user-images.githubusercontent.com/1651191/86829270-382ca780-c062-11ea-9f4d-be8c300ba619.png)
[contourHeightMatchParent, view extended](https://user-images.githubusercontent.com/1651191/86829260-3662e400-c062-11ea-88fc-83a602917f77.png)
[contourHeightWrapContent, view collapsed](https://user-images.githubusercontent.com/1651191/86829275-395dd480-c062-11ea-83c4-0f3977ad02a6.png)
[contourHeightWrapContent, view extended](https://user-images.githubusercontent.com/1651191/86829272-38c53e00-c062-11ea-814a-958585917888.png)
[contourHeightOf with same definition as before this commit, view extended](https://user-images.githubusercontent.com/1651191/86829277-395dd480-c062-11ea-897d-b4462101cdfb.png)
[contourHeightOf with same definition as before this commit, view collapsed](https://user-images.githubusercontent.com/1651191/86829279-39f66b00-c062-11ea-869e-c61fd52f3d6c.png)
