### PR TITLE
Drop unnecessary ExperimentalContracts annotations in sample app

### DIFF
--- a/sample-app/src/main/java/com/squareup/contour/sample/SampleActivity.kt
+++ b/sample-app/src/main/java/com/squareup/contour/sample/SampleActivity.kt
@@ -4,9 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import kotlin.LazyThreadSafetyMode.NONE
-import kotlin.contracts.ExperimentalContracts
 
-@ExperimentalContracts
 class SampleActivity : AppCompatActivity() {
 
   private var i = 0

--- a/sample-app/src/main/java/com/squareup/contour/sample/SampleView1.kt
+++ b/sample-app/src/main/java/com/squareup/contour/sample/SampleView1.kt
@@ -8,10 +8,8 @@ import android.widget.TextView
 import com.squareup.contour.ContourLayout
 import com.squareup.contour.sample.widget.PaddingAdjusterWidget
 import com.squareup.picasso.Picasso
-import kotlin.contracts.ExperimentalContracts
 
 @SuppressLint("SetTextI18n", "ViewConstructor")
-@ExperimentalContracts
 class SampleView1(context: SampleActivity) : ContourLayout(context) {
 
   private val siskoWisdom: String =

--- a/sample-app/src/main/java/com/squareup/contour/sample/SampleView2.kt
+++ b/sample-app/src/main/java/com/squareup/contour/sample/SampleView2.kt
@@ -9,10 +9,8 @@ import android.widget.TextView
 import com.squareup.contour.ContourLayout
 import com.squareup.contour.SizeMode.AtMost
 import com.squareup.picasso.Picasso
-import kotlin.contracts.ExperimentalContracts
 
 @SuppressLint("ViewConstructor")
-@ExperimentalContracts
 class SampleView2(context: SampleActivity) : ContourLayout(context) {
 
   private val names = listOf(

--- a/sample-app/src/main/java/com/squareup/contour/sample/widget/PaddingAdjusterWidget.kt
+++ b/sample-app/src/main/java/com/squareup/contour/sample/widget/PaddingAdjusterWidget.kt
@@ -7,10 +7,8 @@ import androidx.appcompat.widget.AppCompatSeekBar
 import androidx.appcompat.widget.AppCompatTextView
 import com.squareup.contour.ContourLayout
 import com.squareup.contour.sample.SampleActivity
-import kotlin.contracts.ExperimentalContracts
 
 @SuppressLint("ViewConstructor")
-@ExperimentalContracts
 internal class PaddingAdjusterWidget(
     context: SampleActivity,
     private val onPaddingAdjusted: (Rect) -> Unit


### PR DESCRIPTION
We're not currently using anything experimental