### PR TITLE
Remove onInitializeLayout

### DIFF
--- a/contour-lint/src/test/java/com/squareup/contour/lint/NestedContourLayoutsDetectorTest.kt
+++ b/contour-lint/src/test/java/com/squareup/contour/lint/NestedContourLayoutsDetectorTest.kt
@@ -183,7 +183,7 @@ class NestedContourLayoutsDetectorTest {
       |  private val view1 = View(context)
       |  private val view2 = BarView(context)
       | 
-      | override fun onInitializeLayout() {
+      | init {
       |    view1.layoutBy(
       |        x = leftTo { parent.left() },
       |        y = topTo { parent.top() }

--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -149,10 +149,9 @@ private const val WRAP = ViewGroup.LayoutParams.WRAP_CONTENT
  *     )
  *
  *  Where you call [layoutBy] is up to you. There are two available styles. Either calling directly in your child
- *  views [apply] block, or alternatively you can override the method [onInitializeLayout] which will be called
- *  exactly once before layout happens. One thing to note about [layoutBy] is it will add the view to the
- *  [ContourLayout] if not already added. This dictates the draw order - first added will be drawn underneath
- *  everything else.
+ *  views [apply] block, or alternatively in your layout's [init] block. One thing to note about [layoutBy] is it
+ *  will add the view to the [ContourLayout] if not already added. This dictates the draw order - first added
+ *  will be drawn underneath everything else.
  */
 open class ContourLayout(
   context: Context,
@@ -168,16 +167,8 @@ open class ContourLayout(
       paddingConfig = { Rect(paddingLeft, paddingTop, paddingRight, paddingBottom) }
   )
   private var constructed: Boolean = true
-  private var initialized: Boolean = false
   private var lastWidthSpec: Int = 0
   private var lastHeightSpec: Int = 0
-
-  private fun initializeLayout() {
-    if (!initialized) {
-      onInitializeLayout()
-      initialized = true
-    }
-  }
 
   override fun requestLayout() {
     if (constructed) {
@@ -186,16 +177,10 @@ open class ContourLayout(
     super.requestLayout()
   }
 
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    initializeLayout()
-  }
-
   override fun onMeasure(
     widthMeasureSpec: Int,
     heightMeasureSpec: Int
   ) {
-    initializeLayout()
     if (lastWidthSpec != widthMeasureSpec || lastHeightSpec != heightMeasureSpec) {
       invalidateAll()
     }
@@ -261,12 +246,6 @@ open class ContourLayout(
   }
 
   // API
-
-  /**
-   * Option hook in the [ContourLayout] where [layoutBy] can be called on children views
-   * to add and configure before layout. This will be called exactly once before layout.
-   */
-  open fun onInitializeLayout() {}
 
   val Int.dip: Int get() = (density * this).toInt()
   val Int.xdip: XInt get() = XInt((density * this).toInt())
@@ -399,7 +378,7 @@ open class ContourLayout(
    * Usage:
    *
    * ```
-   * override fun onInitializeLayout() {
+   * init {
    *   starDate.layoutBy(
    *     x = leftTo { parent.left() },
    *     y = topTo { parent.top() }

--- a/contour/src/test/kotlin/com/squareup/contour/utils/ContourTestHelpers.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/utils/ContourTestHelpers.kt
@@ -21,7 +21,7 @@ fun contourLayout(
     initializeLayout: ContourLayout.() -> Unit
 ): ContourLayout =
   object : ContourLayout(context) {
-    override fun onInitializeLayout() {
+    init {
       initializeLayout()
     }
   }.layoutSizeOf(width, height)

--- a/sample-app/src/main/java/com/squareup/contour/sample/SampleView1.kt
+++ b/sample-app/src/main/java/com/squareup/contour/sample/SampleView1.kt
@@ -60,6 +60,8 @@ class SampleView1(context: SampleActivity) : ContourLayout(context) {
   init {
     contourHeightWrapContent()
 
+    initializeLayout()
+
     setBackgroundColor(Blue)
     var animated = false
     setOnClickListener {
@@ -79,7 +81,7 @@ class SampleView1(context: SampleActivity) : ContourLayout(context) {
     }
   }
 
-  override fun onInitializeLayout() {
+  private fun initializeLayout() {
     avatar.layoutBy(
         leftTo {
           parent.left()


### PR DESCRIPTION
`onInitializeLayout()` made things a bit less deterministic, because you don't actually know what phase of the view's layout it's getting called in and might therefore lead you to make assumptions about the view's current measurements etc.

Doing layout at initialization time (private val myView = View(context).layoutBy {...) or in init should satisfy everyone's preferences. People can still delegate to a separate method, but it won't be one provided by the library since the library provides no guarantees anyway

### Discussion point
Should this just be deprecated? It'll force a (really simple) migration if we don't deprecate it, but I think that's fine since we're not at 1.0 yet.