### PR TITLE
Allow opting out of default padding behaviour (resolves #78)

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -160,13 +160,32 @@ open class ContourLayout(
   attrs: AttributeSet? = null
 ) : ViewGroup(context, attrs) {
 
+  /**
+   * Whether Contour should respect padding set on this layout as part of laying out its subviews.
+   * When set to `true`, padding will influence the alignment of subviews to the layout's inner edges
+   * When set to `false`, padding will be ignored in all layout calculations.
+   *
+   * This flag exists for the sole purpose of facilitating baby-steps migration from alpha versions
+   * of Contour where padding was not taken into account, allowing devs to migrate one view at a time.
+   *
+   * @see ViewGroup.setPadding
+   */
+  @Deprecated("Migrate implementation to properly take padding into account or explicitly null it out")
+  var respectPadding: Boolean = true
+
   private val density: Float = context.resources.displayMetrics.density
   private val widthConfig = SizeConfig(lambda = matchParent())
   private val heightConfig = SizeConfig(lambda = matchParent())
   private val geometry = ParentGeometry(
       widthConfig = widthConfig,
       heightConfig = heightConfig,
-      paddingConfig = { Rect(paddingLeft, paddingTop, paddingRight, paddingBottom) }
+      paddingConfig = {
+        if (respectPadding) {
+          Rect(paddingLeft, paddingTop, paddingRight, paddingBottom)
+        } else {
+          Rect(0, 0, 0, 0)
+        }
+      }
   )
   private var constructed: Boolean = true
   private var lastWidthSpec: Int = 0

--- a/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
@@ -71,6 +71,47 @@ class ContourTests {
   }
 
   @Test
+  fun `simple single child layout, with padding, respectsPadding disable`() {
+    val plainOldView = View(activity)
+
+    val leftPadding = 1
+    val topPadding = 2
+    val rightPadding = 4
+    val bottomPadding = 8
+
+    val layout = contourLayout(
+        context = activity,
+        width = 200,
+        height = 50
+    ) {
+      respectPadding = false
+      setPadding(leftPadding, topPadding, rightPadding, bottomPadding)
+      plainOldView.layoutBy(
+          leftTo { parent.left() }.rightTo { parent.right() },
+          topTo { parent.top() }.bottomTo { parent.bottom() }
+      )
+    }
+
+    assertThat(plainOldView.left).isEqualTo(0)
+    assertThat(plainOldView.top).isEqualTo(0)
+    assertThat(plainOldView.right).isEqualTo(200)
+    assertThat(plainOldView.bottom).isEqualTo(50)
+    assertThat(plainOldView.width).isEqualTo(200)
+    assertThat(plainOldView.height).isEqualTo(50)
+
+    // Now re-enable respectPadding
+    layout.respectPadding = true
+    layout.forceRelayout()
+
+    assertThat(plainOldView.left).isEqualTo(leftPadding)
+    assertThat(plainOldView.top).isEqualTo(topPadding)
+    assertThat(plainOldView.right).isEqualTo(200 - rightPadding)
+    assertThat(plainOldView.bottom).isEqualTo(50 - bottomPadding)
+    assertThat(plainOldView.width).isEqualTo(200 - leftPadding - rightPadding)
+    assertThat(plainOldView.height).isEqualTo(50 - topPadding - bottomPadding)
+  }
+
+  @Test
   fun `child can be aligned to another child`() {
     val fakeImageView = View(activity)
     val fakeTextView = View(activity)


### PR DESCRIPTION
Immediately deprecated, as it's just a migration nicety for folks.

### OPEN QUESTION
Should we state in the release notes for 1.0.0 that we plan to remove it in 1.1.0? Or is that enough of a breaking change that it should wait for 2.0.0? The burden of maintaining it doesn't seem to warrant trying to get rid of it ASAP.