### PR TITLE
Add a secondary constructor to ContourLayout to make attrs optional

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -157,8 +157,12 @@ private const val WRAP = ViewGroup.LayoutParams.WRAP_CONTENT
  */
 open class ContourLayout(
   context: Context,
-  attrs: AttributeSet? = null
+  attrs: AttributeSet?
 ) : ViewGroup(context, attrs) {
+
+  // Using a secondary constructor instead of @JvmOverloads ensures that
+  // it shows up in autocomplete suggestions when extending ContourLayout.
+  constructor(context: Context): this(context, null)
 
   /**
    * Whether Contour should respect padding set on this layout as part of laying out its subviews.


### PR DESCRIPTION
The second param for `AttributeSet` has a default value, but IntelliJ still requires it to be present everytime when extending `ContourLayout` and it feels like a minor inconvenience. 

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/2387680/89094799-f5769a80-d395-11ea-8904-315cea432f17.jpg) | ![after](https://user-images.githubusercontent.com/2387680/89094800-f7d8f480-d395-11ea-9f86-6b7835540041.jpg) |

