### PR TITLE
Introduce XFloat.toInt() and YFloat.toInt()

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/XFloat.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/XFloat.kt
@@ -49,6 +49,7 @@ inline class XFloat(val value: Float) {
   inline operator fun compareTo(other: XFloat) = value.compareTo(other.value)
 
   inline fun toY() = YFloat(value)
+  inline fun toInt() = XInt(value.toInt())
 
   companion object {
     val ZERO = XFloat(0f)

--- a/contour/src/main/kotlin/com/squareup/contour/YFloat.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/YFloat.kt
@@ -49,6 +49,7 @@ inline class YFloat(val value: Float) {
   inline operator fun compareTo(other: XFloat) = value.compareTo(other.value)
 
   inline fun toX() = XFloat(value)
+  inline fun toInt() = YInt(value.toInt())
 
   companion object {
     val ZERO = YFloat(0f)

--- a/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
@@ -294,6 +294,19 @@ class ContourTests {
   }
 
   @Test
+  fun `conversion of XFloat to XInt and YFloat to YInt`() {
+    val view = View(activity)
+    contourLayout(activity, width = 260, height = 260) {
+      view.layoutBy(
+          leftTo { parent.left() }.widthOf { (parent.width() * 0.42f).toInt() },
+          topTo { parent.top() }.heightOf { (parent.height() * 0.99f).toInt() }
+      )
+    }
+    assertThat(view.width).isEqualTo(109)   // 260 * 0.42 = 109.2 ~= 109 floored
+    assertThat(view.height).isEqualTo(257)  // 260 * 0.99 = 257.4 ~= 257 floored
+  }
+
+  @Test
   fun `view set to GONE does not get laid out and is considered to have position and size 0`() {
     val view = View(activity)
     view.visibility = View.GONE


### PR DESCRIPTION
We've got some axis solvers that accept both Ints and Floats but for others, converting floats manually is verbose:

```kotlin
XInt((name.width() * 0.3f).value.toInt())
```

This PR adds `toInt()` functions to make the conversion slightly nicer:

```kotlin
(name.width() * 0.3f).toInt()
```