### PR TITLE
Fix YInt and YFloat compareTo() to take YInt/YFloat values

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/YFloat.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/YFloat.kt
@@ -44,9 +44,9 @@ inline class YFloat(val value: Float) {
   inline operator fun div(other: YFloat) = YFloat(value / other.value)
 
   inline operator fun compareTo(other: Int) = value.compareTo(other)
-  inline operator fun compareTo(other: XInt) = value.compareTo(other.value)
+  inline operator fun compareTo(other: YInt) = value.compareTo(other.value)
   inline operator fun compareTo(other: Float) = value.compareTo(other)
-  inline operator fun compareTo(other: XFloat) = value.compareTo(other.value)
+  inline operator fun compareTo(other: YFloat) = value.compareTo(other.value)
 
   inline fun toX() = XFloat(value)
   inline fun toInt() = YInt(value.toInt())

--- a/contour/src/main/kotlin/com/squareup/contour/YInt.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/YInt.kt
@@ -44,9 +44,9 @@ inline class YInt(val value: Int) {
   inline operator fun div(other: YFloat) = YFloat(value / other.value)
 
   inline operator fun compareTo(other: Int) = value.compareTo(other)
-  inline operator fun compareTo(other: XInt) = value.compareTo(other.value)
+  inline operator fun compareTo(other: YInt) = value.compareTo(other.value)
   inline operator fun compareTo(other: Float) = value.compareTo(other)
-  inline operator fun compareTo(other: XFloat) = value.compareTo(other.value)
+  inline operator fun compareTo(other: YFloat) = value.compareTo(other.value)
 
   inline fun toX() = XInt(value)
 


### PR DESCRIPTION
Trying to compare to Y values will not work, since the type is declared wrongly.