### PR TITLE
Disable BuildConfig generation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
 android.useAndroidX=true
+# Disable BuildConfig feature by default because no modules in this repository use it
+android.defaults.buildfeatures.buildconfig=false
 
 VERSION_NAME=1.1.0-SNAPSHOT
 GROUP=app.cash.contour


### PR DESCRIPTION
Contour's `BuildConfig` class doesn't appear to carry any specific information useful for client apps so it can be safely disabled. I opted to turn it off by default across the entire build since no subproject appears to be using it, if that's undesirable then I can move it to the contour gradle config.

Diff generated by [diffuse](https://github.com/JakeWharton/diffuse) that confirms `BuildConfig` is not generated on this branch.

```
$ diffuse diff --aar contour-master.aar contour-disable-buildconfig.aar 
OLD: contour-master.aar
NEW: contour-disable-buildconfig.aar

 AAR      │ old       │ new       │ diff   
──────────┼───────────┼───────────┼────────
      jar │ 101.1 KiB │ 100.7 KiB │ -481 B 
 manifest │     202 B │     202 B │    0 B 
 lint-jar │   9.4 KiB │   9.4 KiB │    0 B 
    other │      44 B │      44 B │    0 B 
──────────┼───────────┼───────────┼────────
    total │ 110.8 KiB │ 110.3 KiB │ -481 B 


 JAR     │ old │ new │ diff       
─────────┼─────┼─────┼────────────
 classes │  78 │  77 │ -1 (+0 -1) 
 methods │ 630 │ 629 │ -1 (+0 -1) 
  fields │ 132 │ 129 │ -3 (+0 -3) 


=================
====   AAR   ====
=================

 size      │ diff   │ path          
───────────┼────────┼───────────────
 100.7 KiB │ -481 B │ ∆ classes.jar 
───────────┼────────┼───────────────
 100.7 KiB │ -481 B │ (total)       



=================
====   JAR   ====
=================

CLASSES:

   old │ new │ diff       
  ─────┼─────┼────────────
   78  │ 77  │ -1 (+0 -1) 
  
  - com.squareup.contour.BuildConfig
  

METHODS:

   old │ new │ diff       
  ─────┼─────┼────────────
   630 │ 629 │ -1 (+0 -1) 
  
  - com.squareup.contour.BuildConfig <init>()
  

FIELDS:

   old │ new │ diff       
  ─────┼─────┼────────────
   132 │ 129 │ -3 (+0 -3) 
  
  - com.squareup.contour.BuildConfig BUILD_TYPE: String
  - com.squareup.contour.BuildConfig DEBUG: boolean
  - com.squareup.contour.BuildConfig LIBRARY_PACKAGE_NAME: String
```
