### PR TITLE
Using other axis

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -732,8 +732,10 @@ open class ContourLayout(
     internal fun width(): XInt = x.range().toXInt()
     internal fun height(): YInt = y.range().toYInt()
 
+    internal fun isEmpty() = view.visibility == View.GONE
+
     internal fun preferredWidth(): XInt {
-      return if (view.visibility == View.GONE) {
+      return if (isEmpty()) {
         XInt.ZERO
       } else {
         dimen.measure(0, y.measureSpec())
@@ -742,7 +744,7 @@ open class ContourLayout(
     }
 
     internal fun preferredHeight(): YInt {
-      return if (view.visibility == View.GONE) {
+      return if (isEmpty()) {
         YInt.ZERO
       } else {
         dimen.measure(x.measureSpec(), 0)
@@ -751,7 +753,7 @@ open class ContourLayout(
     }
 
     internal fun measureSelf() {
-      if (view.visibility == View.GONE) {
+      if (isEmpty()) {
         x.onRangeResolved(0, 0)
         y.onRangeResolved(0, 0)
       } else {

--- a/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/ContourLayout.kt
@@ -732,10 +732,8 @@ open class ContourLayout(
     internal fun width(): XInt = x.range().toXInt()
     internal fun height(): YInt = y.range().toYInt()
 
-    internal fun isEmpty() = view.visibility == View.GONE
-
     internal fun preferredWidth(): XInt {
-      return if (isEmpty()) {
+      return if (view.visibility == GONE) {
         XInt.ZERO
       } else {
         dimen.measure(0, y.measureSpec())
@@ -744,7 +742,7 @@ open class ContourLayout(
     }
 
     internal fun preferredHeight(): YInt {
-      return if (isEmpty()) {
+      return if (view.visibility == GONE) {
         YInt.ZERO
       } else {
         dimen.measure(x.measureSpec(), 0)
@@ -753,7 +751,7 @@ open class ContourLayout(
     }
 
     internal fun measureSelf() {
-      if (isEmpty()) {
+      if (view.visibility == GONE) {
         x.onRangeResolved(0, 0)
         y.onRangeResolved(0, 0)
       } else {

--- a/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
@@ -138,7 +138,7 @@ internal class SimpleAxisSolver(
   }
 
   private fun resolveRange() {
-    if (parent.isEmpty()) {
+    if (parent.view.visibility == View.GONE) {
       onRangeResolved(0, 0)
     } else {
       if (p1.isSet && p1.mode == SizeMode.Exact) {

--- a/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
@@ -73,8 +73,7 @@ internal class SimpleAxisSolver(
       } else {
         if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
           parent.measureSelf()
-        }
-        else {
+        } else {
           resolveRange()
         }
         resolveAxis()
@@ -90,8 +89,7 @@ internal class SimpleAxisSolver(
       } else {
         if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
           parent.measureSelf()
-        }
-        else {
+        } else {
           resolveRange()
         }
         resolveAxis()
@@ -107,8 +105,7 @@ internal class SimpleAxisSolver(
       } else {
         if (baselineRange == Int.MIN_VALUE) {
           parent.measureSelf()
-        }
-        else {
+        } else {
           resolveRange()
         }
         resolveAxis()
@@ -124,8 +121,7 @@ internal class SimpleAxisSolver(
       } else {
         if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
           parent.measureSelf()
-        }
-        else {
+        } else {
           resolveRange()
         }
         resolveAxis()

--- a/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
@@ -71,11 +71,7 @@ internal class SimpleAxisSolver(
       if (p0.point == Point.Min) {
         min = p0.resolve()
       } else {
-        if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
-          parent.measureSelf()
-        } else {
-          resolveRange()
-        }
+        resolveRange()
         resolveAxis()
       }
     }
@@ -87,11 +83,7 @@ internal class SimpleAxisSolver(
       if (p0.point == Point.Mid) {
         mid = p0.resolve()
       } else {
-        if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
-          parent.measureSelf()
-        } else {
-          resolveRange()
-        }
+        resolveRange()
         resolveAxis()
       }
     }
@@ -109,7 +101,6 @@ internal class SimpleAxisSolver(
           resolveRange()
         }
         resolveAxis()
-        baseline = min + baselineRange
       }
     }
     return baseline
@@ -120,11 +111,7 @@ internal class SimpleAxisSolver(
       if (p0.point == Point.Max) {
         max = p0.resolve()
       } else {
-        if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
-          parent.measureSelf()
-        } else {
-          resolveRange()
-        }
+        resolveRange()
         resolveAxis()
       }
     }
@@ -142,7 +129,9 @@ internal class SimpleAxisSolver(
     if (parent.view.visibility == View.GONE) {
       onRangeResolved(0, 0)
     } else {
-      if (p1.isSet && p1.mode == SizeMode.Exact) {
+      if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
+        parent.measureSelf()
+      } else if (p1.isSet && p1.mode == SizeMode.Exact) {
         range = abs(p0.resolve() - p1.resolve())
       } else if (size.isSet && size.mode == SizeMode.Exact) {
         range = size.resolve()
@@ -179,6 +168,9 @@ internal class SimpleAxisSolver(
         mid = max - hV
         min = max - range
       }
+    }
+    if (p0.point != Point.Baseline && baselineRange != Int.MIN_VALUE) {
+      baseline = min + baselineRange
     }
   }
 

--- a/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
@@ -71,7 +71,12 @@ internal class SimpleAxisSolver(
       if (p0.point == Point.Min) {
         min = p0.resolve()
       } else {
-        parent.measureSelf()
+        if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
+          parent.measureSelf()
+        }
+        else {
+          resolveRange()
+        }
         resolveAxis()
       }
     }
@@ -83,7 +88,12 @@ internal class SimpleAxisSolver(
       if (p0.point == Point.Mid) {
         mid = p0.resolve()
       } else {
-        parent.measureSelf()
+        if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
+          parent.measureSelf()
+        }
+        else {
+          resolveRange()
+        }
         resolveAxis()
       }
     }
@@ -95,7 +105,12 @@ internal class SimpleAxisSolver(
       if (p0.point == Point.Baseline) {
         baseline = p0.resolve()
       } else {
-        parent.measureSelf()
+        if (baselineRange == Int.MIN_VALUE) {
+          parent.measureSelf()
+        }
+        else {
+          resolveRange()
+        }
         resolveAxis()
       }
     }
@@ -107,7 +122,12 @@ internal class SimpleAxisSolver(
       if (p0.point == Point.Max) {
         max = p0.resolve()
       } else {
-        parent.measureSelf()
+        if (p0.point == Point.Baseline && baselineRange == Int.MIN_VALUE) {
+          parent.measureSelf()
+        }
+        else {
+          resolveRange()
+        }
         resolveAxis()
       }
     }
@@ -116,30 +136,42 @@ internal class SimpleAxisSolver(
 
   override fun range(): Int {
     if (range == Int.MIN_VALUE) {
-      parent.measureSelf()
+      resolveRange()
     }
     return range
   }
 
+  private fun resolveRange() {
+    if (parent.isEmpty()) {
+      onRangeResolved(0, 0)
+    } else {
+      if (p1.isSet && p1.mode == SizeMode.Exact) {
+        range = abs(p0.resolve() - p1.resolve())
+      } else if (size.isSet && size.mode == SizeMode.Exact) {
+        range = size.resolve()
+      } else {
+        parent.measureSelf()
+      }
+    }
+  }
+
   private fun resolveAxis() {
     check(range != Int.MIN_VALUE)
-    check(baselineRange != Int.MIN_VALUE)
 
     val hV = range / 2
     when (p0.point) {
       Point.Min -> {
         min = p0.resolve()
         mid = min + hV
-        baseline = min + baselineRange
         max = min + range
       }
       Point.Mid -> {
         mid = p0.resolve()
         min = mid - hV
-        baseline = min + baselineRange
         max = mid + hV
       }
       Point.Baseline -> {
+        check(baselineRange != Int.MIN_VALUE)
         baseline = p0.resolve()
         min = baseline - baselineRange
         mid = min + hV
@@ -149,7 +181,6 @@ internal class SimpleAxisSolver(
         max = p0.resolve()
         mid = max - hV
         min = max - range
-        baseline = min + baselineRange
       }
     }
   }
@@ -195,6 +226,7 @@ internal class SimpleAxisSolver(
     p1.point = Point.Min
     p1.mode = mode
     p1.lambda = unwrapXIntLambda(provider)
+    baselineRange = 0
     return this
   }
 
@@ -205,6 +237,7 @@ internal class SimpleAxisSolver(
     p1.point = Point.Min
     p1.mode = mode
     p1.lambda = unwrapXFloatLambda(provider)
+    baselineRange = 0
     return this
   }
 
@@ -232,6 +265,7 @@ internal class SimpleAxisSolver(
     p1.point = Point.Max
     p1.mode = mode
     p1.lambda = unwrapXIntLambda(provider)
+    baselineRange = 0
     return this
   }
 
@@ -242,6 +276,7 @@ internal class SimpleAxisSolver(
     p1.point = Point.Max
     p1.mode = mode
     p1.lambda = unwrapXFloatLambda(provider)
+    baselineRange = 0
     return this
   }
 
@@ -268,6 +303,7 @@ internal class SimpleAxisSolver(
   override fun widthOf(mode: SizeMode, provider: LayoutContainer.() -> XInt): XAxisSolver {
     size.mode = mode
     size.lambda = unwrapXIntLambda(provider)
+    baselineRange = 0
     return this
   }
 
@@ -277,6 +313,7 @@ internal class SimpleAxisSolver(
   ): XAxisSolver {
     size.mode = mode
     size.lambda = unwrapXFloatLambda(provider)
+    baselineRange = 0
     return this
   }
 

--- a/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/solvers/SimpleAxisSolver.kt
@@ -109,6 +109,7 @@ internal class SimpleAxisSolver(
           resolveRange()
         }
         resolveAxis()
+        baseline = min + baselineRange
       }
     }
     return baseline

--- a/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
@@ -176,7 +176,7 @@ class ContourTests {
 
   @Test
   fun `unspecified size will fallback to views preferred size`() {
-    val fakeTextView = FakeTextView(activity, "Test", 10)
+    val fakeTextView = FakeTextView(activity, "Test", 10, 0)
 
     contourLayout(activity) {
       fakeTextView.layoutBy(
@@ -413,5 +413,42 @@ class ContourTests {
     assertThat(view.bottom).isEqualTo(125)
     assertThat(view.width).isEqualTo(125)
     assertThat(view.height).isEqualTo(125)
+  }
+
+  @Test
+  fun `simple baseline`() {
+    val fakeTextView = FakeTextView(activity, "Test", 10, 8)
+
+    contourLayout(activity) {
+      fakeTextView.layoutBy(
+              leftTo { parent.left() },
+              baselineTo { 20.ydip }
+      )
+    }
+
+    assertThat(fakeTextView.top).isEqualTo(12)
+    assertThat(fakeTextView.bottom).isEqualTo(22)
+    assertThat(fakeTextView.height).isEqualTo(10)
+  }
+
+  @Test
+  fun `baseline to baseline`() {
+    val fakeTextView1 = FakeTextView(activity, "Hello", 18, 15)
+    val fakeTextView2 = FakeTextView(activity, "World", 12, 10)
+
+    contourLayout(activity) {
+      fakeTextView1.layoutBy(
+              leftTo { parent.left() },
+              topTo { parent.top() }
+      )
+      fakeTextView2.layoutBy(
+              rightTo { parent.right() },
+              baselineTo { fakeTextView1.baseline() }
+      )
+    }
+
+    assertThat(fakeTextView2.top).isEqualTo(5)
+    assertThat(fakeTextView2.bottom).isEqualTo(17)
+    assertThat(fakeTextView2.height).isEqualTo(12)
   }
 }

--- a/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
@@ -376,4 +376,42 @@ class ContourTests {
     assertThat(otherView.width).isEqualTo(10 + 1)
     assertThat(otherView.height).isEqualTo(15 + 2)
   }
+
+  @Test
+  fun `using other axis width constraint`() {
+    val view = View(activity)
+
+    contourLayout(context = activity, width = 200, height = 200) {
+      view.layoutBy(
+              leftTo { parent.left() }.rightTo { parent.right() - 50.dip },
+              topTo { parent.top() }.heightOf { view.width().toY() }
+      )
+    }
+
+    assertThat(view.left).isEqualTo(0)
+    assertThat(view.top).isEqualTo(0)
+    assertThat(view.right).isEqualTo(150)
+    assertThat(view.bottom).isEqualTo(150)
+    assertThat(view.width).isEqualTo(150)
+    assertThat(view.height).isEqualTo(150)
+  }
+
+  @Test
+  fun `using other axis height constraint`() {
+    val view = View(activity)
+
+    contourLayout(context = activity, width = 200, height = 200) {
+      view.layoutBy(
+              leftTo { parent.left() }.rightTo { view.height().toX() },
+              topTo { parent.top() }.bottomTo { 125.ydip }
+      )
+    }
+
+    assertThat(view.left).isEqualTo(0)
+    assertThat(view.top).isEqualTo(0)
+    assertThat(view.right).isEqualTo(125)
+    assertThat(view.bottom).isEqualTo(125)
+    assertThat(view.width).isEqualTo(125)
+    assertThat(view.height).isEqualTo(125)
+  }
 }

--- a/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
@@ -451,4 +451,23 @@ class ContourTests {
     assertThat(fakeTextView2.bottom).isEqualTo(17)
     assertThat(fakeTextView2.height).isEqualTo(12)
   }
+
+  @Test
+  fun `calling baseline() on an unmeasured view should correctly resolve its baseline`() {
+    val view = View(activity)
+    val text = FakeTextView(activity, "Test", 10, 8)
+
+    contourLayout(activity) {
+      view.layoutBy(
+          leftTo { 0.xdip },
+          topTo { text.baseline() }
+      )
+      text.layoutBy(
+          leftTo { 0.xdip },
+          topTo { 0.ydip }.bottomTo { 10.ydip }
+      )
+    }
+
+    assertThat(view.top).isEqualTo(8)
+  }
 }

--- a/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/ContourTests.kt
@@ -383,8 +383,8 @@ class ContourTests {
 
     contourLayout(context = activity, width = 200, height = 200) {
       view.layoutBy(
-              leftTo { parent.left() }.rightTo { parent.right() - 50.dip },
-              topTo { parent.top() }.heightOf { view.width().toY() }
+          leftTo { parent.left() }.rightTo { parent.right() - 50.dip },
+          topTo { parent.top() }.heightOf { view.width().toY() }
       )
     }
 
@@ -402,8 +402,8 @@ class ContourTests {
 
     contourLayout(context = activity, width = 200, height = 200) {
       view.layoutBy(
-              leftTo { parent.left() }.rightTo { view.height().toX() },
-              topTo { parent.top() }.bottomTo { 125.ydip }
+          leftTo { parent.left() }.rightTo { view.height().toX() },
+          topTo { parent.top() }.bottomTo { 125.ydip }
       )
     }
 
@@ -421,8 +421,8 @@ class ContourTests {
 
     contourLayout(activity) {
       fakeTextView.layoutBy(
-              leftTo { parent.left() },
-              baselineTo { 20.ydip }
+          leftTo { parent.left() },
+          baselineTo { 20.ydip }
       )
     }
 
@@ -438,12 +438,12 @@ class ContourTests {
 
     contourLayout(activity) {
       fakeTextView1.layoutBy(
-              leftTo { parent.left() },
-              topTo { parent.top() }
+          leftTo { parent.left() },
+          topTo { parent.top() }
       )
       fakeTextView2.layoutBy(
-              rightTo { parent.right() },
-              baselineTo { fakeTextView1.baseline() }
+          rightTo { parent.right() },
+          baselineTo { fakeTextView1.baseline() }
       )
     }
 

--- a/contour/src/test/kotlin/com/squareup/contour/utils/FakeTextView.kt
+++ b/contour/src/test/kotlin/com/squareup/contour/utils/FakeTextView.kt
@@ -6,7 +6,8 @@ import android.view.View
 class FakeTextView(
   context: Context,
   private val text: String,
-  private val textSize: Int
+  private val textSize: Int,
+  private val baseline: Int
 ) : View(context) {
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
     val availableWidth = MeasureSpec.getSize(widthMeasureSpec)
@@ -22,4 +23,6 @@ class FakeTextView(
         else textSize
     )
   }
+
+  override fun getBaseline(): Int = baseline
 }


### PR DESCRIPTION
If constraint mode is Exact we don't have to call parent.measureSelf() which tries to resolve both axis. This helps to avoid CircularReferenceException on certain scenarios such as when one axis (indirectly) depends on the other.