### PR TITLE
Replace deprecated appendln method

### DIFF
--- a/contour/src/main/kotlin/com/squareup/contour/errors/CircularReferenceDetected.kt
+++ b/contour/src/main/kotlin/com/squareup/contour/errors/CircularReferenceDetected.kt
@@ -32,17 +32,17 @@ class CircularReferenceDetected : Exception() {
     list += trace
   }
 
-  override val message: String?
+  override val message: String
     get() = buildString {
       val count = list.size
-      appendln()
-      appendln()
-      appendln("Circular reference detected through the following calls:")
+      appendLine()
+      appendLine()
+      appendLine("Circular reference detected through the following calls:")
       list.forEachIndexed { i, t ->
         val bullet = "${count - i}) "
         val indent = " ".repeat(bullet.length)
-        append(bullet).appendln("Calling ${t.seenAt?.methodName}() on ${t.view} from:")
-        append(indent).appendln(t.referencedFrom.toString())
+        append(bullet).appendLine("Calling ${t.seenAt?.methodName}() on ${t.view} from:")
+        append(indent).appendLine(t.referencedFrom.toString())
       }
     }
 }


### PR DESCRIPTION
`appendln()` was deprecated. So, We could replace it with `appendLine()`. Also, I've changed the return type of message to non-nullable in this pr. Thanks 😄 

```
@Deprecated(
    "Use appendLine instead. Note that the new method always appends the line feed character '\\n' regardless of the system line separator.",
    ReplaceWith("appendLine()"),
    level = DeprecationLevel.WARNING
)
public fun StringBuilder.appendln(): StringBuilder = append(SystemProperties.LINE_SEPARATOR)
```